### PR TITLE
RPST-2: Add app state

### DIFF
--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,9 +1,26 @@
 export class Model {
-  getScore(key: "player" | "computer"): number {
+  private state = {
+    scores: {
+      player: 0,
+      computer: 0,
+    },
+  };
+
+  constructor() {
+    this.state.scores.player = this.getScoreFromStorage("player");
+    this.state.scores.computer = this.getScoreFromStorage("computer");
+  }
+
+  private getScoreFromStorage(key: "player" | "computer"): number {
     return parseInt(localStorage.getItem(`${key}Score`) || "0", 10);
   }
 
+  getScore(key: "player" | "computer"): number {
+    return this.state.scores[key];
+  }
+
   setScore(key: "player" | "computer", value: number): void {
+    this.state.scores[key] = value;
     localStorage.setItem(`${key}Score`, value.toString());
   }
 }


### PR DESCRIPTION
As a player, I want my win count and the computer's win count to persist across page reloads, so I can track progress over time.

Win counts are stored in local storage and collected in state.

On page reload, the stored values are still displayed on the scoreboard.