### PR TITLE
RPST-6: Add score update

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,6 +1,7 @@
 import { Model } from "../model/model";
 import { View } from "../view";
 import { Move } from "../utils/dataObjectUtils";
+import { MOVES } from "../utils/dataUtils";
 
 export class Controller {
   private model: Model;
@@ -11,17 +12,21 @@ export class Controller {
     this.view = view;
   }
 
-  initialize(): void {
-    this.view.updateMessage("Rock, Paper, Scissors, Tara");
+  private updateScoreView(): void {
     this.view.updateScores(
       this.model.getScore("player"),
       this.model.getScore("computer")
     );
+  }
 
-    ["rock", "paper", "scissors"].forEach((id) => {
+  initialize(): void {
+    this.view.updateMessage("Rock, Paper, Scissors, Tara");
+    this.updateScoreView();
+
+    MOVES.map((m) => m.name).forEach((id) => {
       document
         .getElementById(id)
-        ?.addEventListener("click", () => this.handlePlayerMove(id as Move));
+        ?.addEventListener("click", () => this.handlePlayerMove(id));
     });
 
     document
@@ -40,5 +45,6 @@ export class Controller {
     this.view.showMoves(playerMove, computerMove, result);
     this.view.toggleMoveButtons(false);
     this.view.togglePlayAgain(true);
+    this.updateScoreView();
   }
 }

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -5,8 +5,8 @@ describe("Model", () => {
   let model: Model;
 
   beforeEach(() => {
-    model = new Model();
     localStorage.clear();
+    model = new Model();
   });
 
   // ===== Score Tests =====
@@ -77,22 +77,31 @@ describe("Model", () => {
       expect(model.evaluateRound()).toBe("Invalid round");
     });
 
-    test("returns 'It's a tie!' if both moves are the same", () => {
+    test("does not update scores on tie", () => {
       model.setPlayerMove("scissors");
       model.setComputerMove("scissors");
+
       expect(model.evaluateRound()).toBe("It's a tie!");
+      expect(model.getScore("player")).toBe(0);
+      expect(model.getScore("computer")).toBe(0);
     });
 
-    test("returns 'You win!' if player beats computer", () => {
+    test("returns 'You win!' if player beats computer and updates score", () => {
       model.setPlayerMove("rock");
       model.setComputerMove("scissors");
+
       expect(model.evaluateRound()).toBe("You win!");
+      expect(model.getScore("player")).toBe(1);
+      expect(model.getScore("computer")).toBe(0);
     });
 
-    test("returns 'Computer wins!' if computer beats player", () => {
+    test("returns 'Computer wins!' if computer beats player and updates score", () => {
       model.setPlayerMove("paper");
       model.setComputerMove("scissors");
+
       expect(model.evaluateRound()).toBe("Computer wins!");
+      expect(model.getScore("computer")).toBe(1);
+      expect(model.getScore("player")).toBe(0);
     });
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -32,8 +32,10 @@ export class Model {
     const playerWins = playerMoveData?.beats.includes(computerMove);
 
     if (playerWins) {
+      this.setScore("player", this.getScore("player") + 1);
       return "You win!";
     } else {
+      this.setScore("computer", this.getScore("computer") + 1);
       return "Computer wins!";
     }
   }


### PR DESCRIPTION
As a player, I want the winner's score to increase after each round, so the scoreboard stays accurate.

The winner's score increments by 1.
The updated score is displayed on the scoreboard and stored in local storage.