### PR TITLE
RPST-8: Add tara gain logic

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -21,6 +21,7 @@ describe("Controller", () => {
       getComputerMove: jest.fn().mockReturnValue("scissors"),
       evaluateRound: jest.fn().mockReturnValue("You win!"),
       increaseRoundNumber: jest.fn(),
+      getTaraCount: jest.fn().mockReturnValue(0),
     };
 
     mockView = {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -35,6 +35,9 @@ export class Controller {
     this.view.togglePlayAgain(true);
     this.model.increaseRoundNumber();
     this.updateScoreView();
+
+    console.log("Player Taras:", this.model.getTaraCount("player"));
+    console.log("Computer Taras:", this.model.getTaraCount("computer"));
   }
 
   private handlePlayerMove(move: Move): void {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -11,19 +11,39 @@ export class Model {
       player: null,
       computer: null,
     },
+    taras: {
+      player: 0,
+      computer: 0,
+    },
     roundNumber: 1,
   };
 
   constructor() {
     this.state.scores.player = this.getScoreFromStorage("player");
     this.state.scores.computer = this.getScoreFromStorage("computer");
+    this.state.taras.player = this.getTaraCountFromStorage("player");
+    this.state.taras.computer = this.getTaraCountFromStorage("computer");
     this.state.roundNumber = this.getRoundNumberFromStorage();
   }
 
   // ===== General Methods =====
 
-  doesMoveBeat(a: Move, b: Move): boolean {
+  private doesMoveBeat(a: Move, b: Move): boolean {
     return MOVE_MAP.get(a)?.beats.includes(b) ?? false;
+  }
+
+  private handleRoundWin(
+    winner: "player" | "computer",
+    winningMove: Move
+  ): void {
+    this.setScore(winner, this.getScore(winner) + 1);
+
+    if (this.isStandardMove(winningMove)) {
+      const currentTara = this.getTaraCount(winner);
+      if (currentTara < 3) {
+        this.setTaraCount(winner, currentTara + 1);
+      }
+    }
   }
 
   evaluateRound(): string {
@@ -34,10 +54,10 @@ export class Model {
     if (playerMove === computerMove) return "It's a tie!";
 
     if (this.doesMoveBeat(playerMove, computerMove)) {
-      this.setScore("player", this.getScore("player") + 1);
+      this.handleRoundWin("player", playerMove);
       return "You win!";
     } else {
-      this.setScore("computer", this.getScore("computer") + 1);
+      this.handleRoundWin("computer", computerMove);
       return "Computer wins!";
     }
   }
@@ -85,6 +105,10 @@ export class Model {
     this.setComputerMove(MOVES[randomIndex].name);
   }
 
+  private isStandardMove(move: Move): boolean {
+    return move !== "tara";
+  }
+
   // ===== Round Methods =====
 
   private getRoundNumberFromStorage(): number {
@@ -102,5 +126,20 @@ export class Model {
 
   increaseRoundNumber(): void {
     this.setRoundNumber(this.getRoundNumber() + 1);
+  }
+
+  // ===== Tara Methods =====
+
+  private getTaraCountFromStorage(key: "player" | "computer"): number {
+    return parseInt(localStorage.getItem(`${key}TaraCount`) || "0", 10);
+  }
+
+  getTaraCount(key: "player" | "computer"): number {
+    return this.state.taras[key];
+  }
+
+  setTaraCount(key: "player" | "computer", value: number): void {
+    this.state.taras[key] = value;
+    localStorage.setItem(`${key}TaraCount`, value.toString());
   }
 }

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -16,5 +16,9 @@ export interface GameState {
     player: Move | null;
     computer: Move | null;
   };
+  taras: {
+    player: number;
+    computer: number;
+  };
   roundNumber: number;
 }

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -4,8 +4,15 @@ export const MOVES = [
   { name: "rock", beats: ["scissors"] },
   { name: "paper", beats: ["rock"] },
   { name: "scissors", beats: ["paper"] },
+  { name: "tara", beats: ["rock", "paper", "scissors"] },
 ] as const;
 
 export const MOVE_MAP: ReadonlyMap<Move, MoveData> = new Map(
   MOVES.map((move) => [move.name, move])
+);
+
+export const STANDARD_MOVES = MOVES.filter((move) => move.name !== "tara");
+
+export const STANDARD_MOVE_MAP: ReadonlyMap<Move, MoveData> = new Map(
+  STANDARD_MOVES.map((move) => [move.name, move])
 );


### PR DESCRIPTION
RPST-8: As a player, I want to earn a Tara when I win a round using Rock, Paper, or Scissors, so I can unlock a powerful move.

Each time I win a round using Rock, Paper, or Scissors, my Tara count increases by 1 (up to a maximum of 3).
Winning a round by choosing Tara does not earn an additional Tara.
The player Tara move count is stored in local storage.