### PR TITLE
RPST-9: Add tara count

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,15 +8,42 @@
   <body>
     <h1 id="message">Loading...</h1>
 
+    <!-- Scoreboard Table -->
     <table border="1">
-      <tr>
-        <th>Player</th>
-        <th>Computer</th>
-      </tr>
-      <tr>
-        <td id="player-score">0</td>
-        <td id="computer-score">0</td>
-      </tr>
+      <caption>
+        Scoreboard (Round Wins)
+      </caption>
+      <thead>
+        <tr>
+          <th>Player</th>
+          <th>Computer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td id="player-score">0</td>
+          <td id="computer-score">0</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Tara Count Table -->
+    <table border="1">
+      <caption>
+        Tara Count
+      </caption>
+      <thead>
+        <tr>
+          <th>Player</th>
+          <th>Computer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td id="player-tara">0</td>
+          <td id="computer-tara">0</td>
+        </tr>
+      </tbody>
     </table>
 
     <button id="start-game">Start Game</button>

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -32,6 +32,7 @@ describe("Controller", () => {
       togglePlayAgain: jest.fn(),
       toggleStartButton: jest.fn(),
       resetForNextRound: jest.fn(),
+      updateTaraCounts: jest.fn(),
     };
 
     controller = new Controller(mockModel, mockView);
@@ -89,5 +90,6 @@ describe("Controller", () => {
     expect(mockView.toggleMoveButtons).toHaveBeenCalledWith(false);
     expect(mockView.togglePlayAgain).toHaveBeenCalledWith(true);
     expect(mockView.updateScores).toHaveBeenCalledWith(0, 0);
+    expect(mockView.updateTaraCounts).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -18,6 +18,12 @@ export class Controller {
       this.model.getScore("computer")
     );
   }
+  private updateTaraView(): void {
+    this.view.updateTaraCounts(
+      this.model.getTaraCount("player"),
+      this.model.getTaraCount("computer")
+    );
+  }
 
   private startGame(): void {
     this.view.toggleStartButton(false);
@@ -35,9 +41,7 @@ export class Controller {
     this.view.togglePlayAgain(true);
     this.model.increaseRoundNumber();
     this.updateScoreView();
-
-    console.log("Player Taras:", this.model.getTaraCount("player"));
-    console.log("Computer Taras:", this.model.getTaraCount("computer"));
+    this.updateTaraView();
   }
 
   private handlePlayerMove(move: Move): void {
@@ -54,6 +58,7 @@ export class Controller {
   initialize(): void {
     this.view.updateMessage("Rock, Paper, Scissors, Tara");
     this.updateScoreView();
+    this.updateTaraView();
     this.view.toggleMoveButtons(false);
     this.view.togglePlayAgain(false);
     this.view.toggleStartButton(true);

--- a/src/view.ts
+++ b/src/view.ts
@@ -66,4 +66,13 @@ export class View {
     if (this.computerScoreEl)
       this.computerScoreEl.textContent = computer.toString();
   }
+
+  // ===== Tara Methods =====
+
+  updateTaraCounts(playerCount: number, computerCount: number): void {
+    document.getElementById("player-tara")!.textContent =
+      playerCount.toString();
+    document.getElementById("computer-tara")!.textContent =
+      computerCount.toString();
+  }
 }


### PR DESCRIPTION
As a player, I want to see my Tara count, so I can track how many I have.

The player's current Tara count is displayed near the scoreboard.
On page reload, the stored Tara count is still accurately displayed.