### PR TITLE
RPST-10: Add tara button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,7 @@
     <button id="rock">Rock</button>
     <button id="paper">Paper</button>
     <button id="scissors">Scissors</button>
+    <button id="tara" disabled>Tara</button>
 
     <p id="round-moves" style="display: none"></p>
     <h2 id="round-result" style="display: none"></h2>

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -10,6 +10,7 @@ describe("Controller", () => {
       <button id="rock"></button>
       <button id="paper"></button>
       <button id="scissors"></button>
+      <button id="tara">Tara</button>
     `;
 
     mockModel = {
@@ -22,6 +23,7 @@ describe("Controller", () => {
       evaluateRound: jest.fn().mockReturnValue("You win!"),
       increaseRoundNumber: jest.fn(),
       getTaraCount: jest.fn().mockReturnValue(0),
+      taraIsEnabled: jest.fn(),
     };
 
     mockView = {
@@ -33,6 +35,7 @@ describe("Controller", () => {
       toggleStartButton: jest.fn(),
       resetForNextRound: jest.fn(),
       updateTaraCounts: jest.fn(),
+      updateTaraButton: jest.fn(),
     };
 
     controller = new Controller(mockModel, mockView);
@@ -71,6 +74,12 @@ describe("Controller", () => {
     expect(mockModel.setPlayerMove).toHaveBeenCalledWith("scissors");
   });
 
+  test("clicking tara button sets player move to 'tara'", () => {
+    controller.initialize();
+    document.getElementById("tara")!.click();
+    expect(mockModel.setPlayerMove).toHaveBeenCalledWith("tara");
+  });
+
   test("clicking a move button triggers computer to choose a move", () => {
     controller.initialize();
     document.getElementById("rock")!.click();
@@ -91,5 +100,6 @@ describe("Controller", () => {
     expect(mockView.togglePlayAgain).toHaveBeenCalledWith(true);
     expect(mockView.updateScores).toHaveBeenCalledWith(0, 0);
     expect(mockView.updateTaraCounts).toHaveBeenCalledWith(0, 0);
+    expect(mockView.updateTaraButton).toHaveBeenCalled();
   });
 });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -25,6 +25,11 @@ export class Controller {
     );
   }
 
+  private updateTaraButtonView(): void {
+    const isEnabled = this.model.taraIsEnabled();
+    this.view.updateTaraButton(isEnabled);
+  }
+
   private startGame(): void {
     this.view.toggleStartButton(false);
     this.view.toggleMoveButtons(true);
@@ -42,6 +47,7 @@ export class Controller {
     this.model.increaseRoundNumber();
     this.updateScoreView();
     this.updateTaraView();
+    this.updateTaraButtonView();
   }
 
   private handlePlayerMove(move: Move): void {
@@ -59,6 +65,7 @@ export class Controller {
     this.view.updateMessage("Rock, Paper, Scissors, Tara");
     this.updateScoreView();
     this.updateTaraView();
+    this.updateTaraButtonView();
     this.view.toggleMoveButtons(false);
     this.view.togglePlayAgain(false);
     this.view.toggleStartButton(true);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -142,4 +142,8 @@ export class Model {
     this.state.taras[key] = value;
     localStorage.setItem(`${key}TaraCount`, value.toString());
   }
+
+  taraIsEnabled(): boolean {
+    return this.getTaraCount("player") > 0;
+  }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,5 @@
 import { Move } from "./utils/dataObjectUtils";
+import { MOVES } from "./utils/dataUtils";
 
 export class View {
   private messageEl = document.getElementById("message");
@@ -6,6 +7,7 @@ export class View {
   private computerScoreEl = document.getElementById("computer-score");
   private movesEl = document.getElementById("round-moves")!;
   private resultEl = document.getElementById("round-result")!;
+  private taraBtn = document.getElementById("tara")!;
 
   // ===== General Methods =====
 
@@ -40,8 +42,8 @@ export class View {
   }
 
   toggleMoveButtons(show: boolean): void {
-    ["rock", "paper", "scissors"].forEach((id) => {
-      const btn = document.getElementById(id);
+    MOVES.forEach(({ name }) => {
+      const btn = document.getElementById(name);
       if (btn) btn.style.display = show ? "inline" : "none";
     });
   }
@@ -74,5 +76,12 @@ export class View {
       playerCount.toString();
     document.getElementById("computer-tara")!.textContent =
       computerCount.toString();
+  }
+
+  updateTaraButton(isEnabled: boolean): void {
+    console.log(isEnabled);
+    if (this.taraBtn instanceof HTMLButtonElement) {
+      this.taraBtn.disabled = !isEnabled;
+    }
   }
 }


### PR DESCRIPTION
As a player, I want to choose Tara, if I have at least 1, so I can almost guarantee a win.

If my Tara count is 1 or more, Tara is an enabled selectable option.
If my Tara count is 0, Tara is disabled.
The Tara move does not win played against itself. That’s a super tie or something.
Clicking the tara button sets the players move to “tara”