### PR TITLE
RPST-11: Add tara decrement logic

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -27,7 +27,8 @@ export class Controller {
 
   private updateTaraButtonView(): void {
     const isEnabled = this.model.taraIsEnabled();
-    this.view.updateTaraButton(isEnabled);
+    const taraCount = this.model.getTaraCount("player");
+    this.view.updateTaraButton(isEnabled, taraCount);
   }
 
   private startGame(): void {

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -183,5 +183,25 @@ describe("Model", () => {
       // Should still be the same since Tara doesn't earn Tara
       expect(model.getTaraCount("player")).toBe(initialTaraCount);
     });
+
+    test("Playing Tara decreases Tara count by 1 for player", () => {
+      model.setTaraCount("player", 2);
+      model.setPlayerMove("tara");
+      model.setComputerMove("rock");
+
+      model.evaluateRound();
+
+      expect(model.getTaraCount("player")).toBe(1);
+    });
+
+    test("Computer's Tara count decreases by 1 when it plays Tara", () => {
+      model.setTaraCount("computer", 1);
+      model.setPlayerMove("rock");
+      model.setComputerMove("tara");
+
+      model.evaluateRound();
+
+      expect(model.getTaraCount("computer")).toBe(0);
+    });
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -51,6 +51,10 @@ export class Model {
     const computerMove = this.getComputerMove();
 
     if (playerMove === null || computerMove === null) return "Invalid round";
+
+    this.handleTaraMove("player", playerMove);
+    this.handleTaraMove("computer", computerMove);
+
     if (playerMove === computerMove) return "It's a tie!";
 
     if (this.doesMoveBeat(playerMove, computerMove)) {
@@ -132,6 +136,15 @@ export class Model {
 
   private getTaraCountFromStorage(key: "player" | "computer"): number {
     return parseInt(localStorage.getItem(`${key}TaraCount`) || "0", 10);
+  }
+
+  private decrementTaraCount(key: "player" | "computer"): void {
+    const current = this.getTaraCount(key);
+    if (current > 0) this.setTaraCount(key, current - 1);
+  }
+
+  private handleTaraMove(key: "player" | "computer", move: Move): void {
+    if (move === "tara") this.decrementTaraCount(key);
   }
 
   getTaraCount(key: "player" | "computer"): number {

--- a/src/view.ts
+++ b/src/view.ts
@@ -78,9 +78,11 @@ export class View {
       computerCount.toString();
   }
 
-  updateTaraButton(isEnabled: boolean): void {
+  updateTaraButton(isEnabled: boolean, taraCount: number): void {
     if (this.taraBtn instanceof HTMLButtonElement) {
       this.taraBtn.disabled = !isEnabled;
     }
+
+    this.taraBtn.textContent = `Tara (x${taraCount})`;
   }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -79,7 +79,6 @@ export class View {
   }
 
   updateTaraButton(isEnabled: boolean): void {
-    console.log(isEnabled);
     if (this.taraBtn instanceof HTMLButtonElement) {
       this.taraBtn.disabled = !isEnabled;
     }


### PR DESCRIPTION
As a player, I want my Tara count to decrease by 1 after using it, so the game tracks my remaining Taras.

When I play Tara, my Tara count decreases by 1.
The updated Tara count is displayed and stored in local storage.