### PR TITLE
RPST-13: Add computer tara limit

### DIFF
--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -1,5 +1,6 @@
 import { Model } from "./model";
 import { MOVES, STANDARD_MOVE_MAP } from "../utils/dataUtils";
+import { Move } from "../utils/dataObjectUtils";
 
 describe("Model", () => {
   let model: Model;
@@ -203,5 +204,47 @@ describe("Model", () => {
 
       expect(model.getTaraCount("computer")).toBe(0);
     });
+  });
+});
+
+// Utility to count frequency over many runs
+function simulateComputerChoices(
+  model: Model,
+  runs = 1000
+): Record<Move, number> {
+  const results: Record<Move, number> = {
+    rock: 0,
+    paper: 0,
+    scissors: 0,
+    tara: 0,
+  };
+
+  for (let i = 0; i < runs; i++) {
+    model.chooseComputerMove();
+    const move = model.getComputerMove();
+    if (move) results[move]++;
+  }
+
+  return results;
+}
+
+describe("Model - chooseComputerMove", () => {
+  it("should never choose tara when tara count is 0", () => {
+    const model = new Model();
+    model.setTaraCount("computer", 0);
+
+    const results = simulateComputerChoices(model, 500);
+
+    expect(results.tara).toBe(0);
+  });
+
+  it("should sometimes choose tara when tara count is > 0", () => {
+    const model = new Model();
+    model.setTaraCount("computer", 5);
+
+    const results = simulateComputerChoices(model, 500);
+
+    // Allow a small chance that tara isn't chosen due to randomness
+    expect(results.tara).toBeGreaterThan(0);
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,5 +1,5 @@
 import { GameState, Move } from "../utils/dataObjectUtils";
-import { MOVES, MOVE_MAP } from "../utils/dataUtils";
+import { MOVES, MOVE_MAP, STANDARD_MOVES } from "../utils/dataUtils";
 
 export class Model {
   private state: GameState = {
@@ -105,8 +105,11 @@ export class Model {
   }
 
   chooseComputerMove(): void {
-    const randomIndex = Math.floor(Math.random() * MOVES.length);
-    this.setComputerMove(MOVES[randomIndex].name);
+    const hasTara = this.getTaraCount("computer") > 0;
+    const availableMoves = hasTara ? MOVES : STANDARD_MOVES;
+
+    const randomIndex = Math.floor(Math.random() * availableMoves.length);
+    this.setComputerMove(availableMoves[randomIndex].name);
   }
 
   private isStandardMove(move: Move): boolean {


### PR DESCRIPTION
As a player, I want the computer to have a Tara count and the ability to play Tara, so the game remains challenging.

The computer has a Tara count, which is tracked in the game state.
If the computer wins a round using Rock, Paper, or Scissors, its Tara count increases by 1 (up to a maximum of 3).
The computer can randomly choose to play Tara if it has at least 1 available.
When the computer plays Tara, its Tara count decreases by 1.
The computer cannot choose Tara if it’s taraCount is 0.