### PR TITLE
RPST-14: Add move history & most common move

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -19,7 +19,6 @@ describe("Controller", () => {
       getComputerScore: jest.fn().mockReturnValue(0),
       setPlayerScore: jest.fn(),
       setComputerScore: jest.fn(),
-      setPlayerMove: jest.fn(),
       getPlayerMove: jest.fn().mockReturnValue(MOVES.ROCK),
       setComputerMove: jest.fn(),
       getComputerMove: jest.fn().mockReturnValue(MOVES.SCISSORS),
@@ -33,6 +32,7 @@ describe("Controller", () => {
       resetScores: jest.fn(),
       resetTaras: jest.fn(),
       resetRoundNumber: jest.fn(),
+      registerPlayerMove: jest.fn(),
     };
 
     mockView = {
@@ -71,25 +71,25 @@ describe("Controller", () => {
     const rockBtn = document.getElementById(MOVES.ROCK)!;
     rockBtn.click();
 
-    expect(mockModel.setPlayerMove).toHaveBeenCalledWith(MOVES.ROCK);
+    expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.ROCK);
   });
 
   test("clicking paper button sets player move to 'paper'", () => {
     controller.initialize();
     document.getElementById(MOVES.PAPER)!.click();
-    expect(mockModel.setPlayerMove).toHaveBeenCalledWith(MOVES.PAPER);
+    expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.PAPER);
   });
 
   test("clicking scissors button sets player move to 'scissors'", () => {
     controller.initialize();
     document.getElementById(MOVES.SCISSORS)!.click();
-    expect(mockModel.setPlayerMove).toHaveBeenCalledWith(MOVES.SCISSORS);
+    expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.SCISSORS);
   });
 
   test("clicking tara button sets player move to 'tara'", () => {
     controller.initialize();
     document.getElementById(MOVES.TARA)!.click();
-    expect(mockModel.setPlayerMove).toHaveBeenCalledWith(MOVES.TARA);
+    expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.TARA);
   });
 
   test("clicking a move button triggers computer to choose a move", () => {
@@ -115,14 +115,14 @@ describe("Controller", () => {
     expect(mockView.updateTaraButton).toHaveBeenCalled();
   });
 
-  test("should call resetMoves before setPlayerMove", () => {
+  test("should call resetMoves before registerPlayerMove", () => {
     const resetSpy = jest.spyOn(mockModel, "resetMoves");
-    const setPlayerMoveSpy = jest.spyOn(mockModel, "setPlayerMove");
+    const registerPlayerMoveSpy = jest.spyOn(mockModel, "registerPlayerMove");
 
     controller.handlePlayerMove(MOVES.SCISSORS);
 
     const resetCall = resetSpy.mock.invocationCallOrder[0];
-    const setMoveCall = setPlayerMoveSpy.mock.invocationCallOrder[0];
+    const setMoveCall = registerPlayerMoveSpy.mock.invocationCallOrder[0];
 
     expect(resetCall).toBeLessThan(setMoveCall);
   });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -70,8 +70,9 @@ export class Controller {
 
   handlePlayerMove(move: Move): void {
     this.model.resetMoves();
-    this.model.setPlayerMove(move);
+    this.model.registerPlayerMove(move);
     this.model.chooseComputerMove();
+
     this.endRound();
   }
 

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -304,4 +304,40 @@ describe("Model", () => {
     expect(model.getPlayerTaraCount()).toBe(0);
     expect(model.getComputerTaraCount()).toBe(0);
   });
+
+  // ===== History Tests =====
+
+  test("registerPlayerMove adds standard move to history", () => {
+    model.registerPlayerMove(MOVES.ROCK);
+    expect(model.getPlayerHistory()).toContain(MOVES.ROCK);
+    expect(localStorage.getItem("playerHistory")).toContain(MOVES.ROCK);
+  });
+
+  test("registerPlayerMove does not add 'tara' to history", () => {
+    model.registerPlayerMove(MOVES.TARA);
+    expect(model.getPlayerHistory()).not.toContain(MOVES.TARA);
+  });
+
+  test("setHistory stores move and updates localStorage", () => {
+    model.setPlayerHistory("paper");
+    expect(model.getPlayerHistory()).toContain("paper");
+    expect(JSON.parse(localStorage.getItem("playerHistory")!)).toContain(
+      "paper"
+    );
+  });
+
+  test("getComputerHistory returns empty array if no localStorage data", () => {
+    localStorage.removeItem("computerHistory");
+
+    const newModel = new Model(); // simulate app reload
+    expect(newModel.getComputerHistory()).toEqual([]);
+  });
+
+  test("getPlayerHistory handles corrupted localStorage gracefully", () => {
+    localStorage.setItem("playerHistory", "{not: valid}");
+
+    const newModel = new Model(); // simulate app reload
+    expect(() => newModel.getPlayerHistory()).not.toThrow();
+    expect(newModel.getPlayerHistory()).toEqual([]);
+  });
 });

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -1,17 +1,19 @@
 import { MOVES, PARTICIPANTS } from "./dataUtils";
 
 export type Move = (typeof MOVES)[keyof typeof MOVES];
+export type StandardMove = Exclude<Move, "tara">;
+
+export type Participant = (typeof PARTICIPANTS)[keyof typeof PARTICIPANTS];
 
 export type MoveData = {
   name: Move;
   beats: readonly Move[];
 };
 
-export type Participant = (typeof PARTICIPANTS)[keyof typeof PARTICIPANTS];
-
 export interface GameState {
   scores: Record<Participant, number>;
   moves: Record<Participant, Move | null>;
   taras: Record<Participant, number>;
+  history: Record<Participant, StandardMove[]>;
   roundNumber: number;
 }


### PR DESCRIPTION
Persist player and computer standard move history, and most common move, in the app data and local storage.

Player and computer standard move history is stored in local storage as they play.
Tara plays are not tracked.
Player and computer most common standard move is calculated from their history and saved/available in local storage.