### PR TITLE
CLEANUP-3: Most Common Move Recalculation Efficiency

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -34,6 +34,7 @@ describe("Controller", () => {
       resetRoundNumber: jest.fn(),
       registerPlayerMove: jest.fn(),
       resetHistories: jest.fn(),
+      resetBothMoveCounts: jest.fn(),
       resetMostCommonMoves: jest.fn(),
       getPlayerMostCommonMove: jest.fn(),
       getComputerMostCommonMove: jest.fn(),
@@ -181,6 +182,7 @@ describe("Controller", () => {
     expect(mockModel.resetTaras).toHaveBeenCalled();
     expect(mockModel.resetRoundNumber).toHaveBeenCalled();
     expect(mockModel.resetHistories).toHaveBeenCalled();
+    expect(mockModel.resetBothMoveCounts).toHaveBeenCalled();
     expect(mockModel.resetMostCommonMoves).toHaveBeenCalled();
 
     expect((controller as any).updateScoreView).toHaveBeenCalled();

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -79,6 +79,7 @@ export class Controller {
     this.model.resetTaras();
     this.model.resetRoundNumber();
     this.model.resetHistories();
+    this.model.resetBothMoveCounts();
     this.model.resetMostCommonMoves();
 
     this.updateScoreView();

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -348,6 +348,27 @@ describe("Model", () => {
       expect(model.getPlayerHistory()).toEqual([]);
       expect(model.getComputerHistory()).toEqual([]);
     });
+
+    test("resetBothMoveCounts resets both participants' localStorage counts", () => {
+      model["state"].moveCounts.player = {
+        rock: 1,
+        paper: 0,
+        scissors: 0,
+      };
+      model["state"].moveCounts.computer = {
+        rock: 0,
+        paper: 0,
+        scissors: 1,
+      };
+
+      model.resetBothMoveCounts();
+
+      const playerStorage = localStorage.getItem("playerMoveCounts");
+      const computerStorage = localStorage.getItem("computerMoveCounts");
+
+      expect(JSON.parse(playerStorage!)).toEqual(null);
+      expect(JSON.parse(computerStorage!)).toEqual(null);
+    });
   });
 
   describe("History", () => {
@@ -388,20 +409,24 @@ describe("Model", () => {
 
   describe("Most Common Move", () => {
     test("sets and gets most common move for player", () => {
-      model["state"].history.player = [MOVES.ROCK, MOVES.ROCK, MOVES.PAPER];
+      model["state"].moveCounts.player = {
+        rock: 1,
+        paper: 3,
+        scissors: 2,
+      };
 
       model.setPlayerMostCommonMove();
       const result = model.getPlayerMostCommonMove();
 
-      expect(result).toBe(MOVES.ROCK);
+      expect(result).toBe(MOVES.PAPER);
     });
 
     test("sets and gets most common move for computer", () => {
-      model["state"].history.computer = [
-        MOVES.SCISSORS,
-        MOVES.SCISSORS,
-        MOVES.ROCK,
-      ];
+      model["state"].moveCounts.computer = {
+        rock: 1,
+        paper: 0,
+        scissors: 2,
+      };
 
       model.setComputerMostCommonMove();
       const result = model.getComputerMostCommonMove();
@@ -410,11 +435,11 @@ describe("Model", () => {
     });
 
     test("persists most common move to localStorage", () => {
-      model["state"].history.player = [
-        MOVES.PAPER,
-        MOVES.PAPER,
-        MOVES.SCISSORS,
-      ];
+      model["state"].moveCounts.player = {
+        rock: 0,
+        paper: 2,
+        scissors: 1,
+      };
 
       model.setPlayerMostCommonMove();
       const stored = localStorage.getItem("playerMostCommonMove");

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -330,8 +330,8 @@ describe("Model", () => {
 
       model.resetHistories();
 
-      expect(localStorage.getItem("playerHistory")).toBe("[]");
-      expect(localStorage.getItem("computerHistory")).toBe("[]");
+      expect(localStorage.getItem("playerHistory")).toBe(null);
+      expect(localStorage.getItem("computerHistory")).toBe(null);
     });
 
     test("resetHistories clears histories from state", () => {
@@ -350,16 +350,27 @@ describe("Model", () => {
     });
 
     test("resetBothMoveCounts resets both participants' localStorage counts", () => {
-      model["state"].moveCounts.player = {
+      const playerMoveCounts = {
         rock: 1,
-        paper: 0,
+        paper: 1,
         scissors: 0,
       };
-      model["state"].moveCounts.computer = {
-        rock: 0,
+      const computerMoveCounts = {
+        rock: 1,
         paper: 0,
         scissors: 1,
       };
+
+      model.registerPlayerMove(MOVES.ROCK);
+      model.registerPlayerMove(MOVES.PAPER);
+      model.registerComputerMove(MOVES.SCISSORS);
+      model.registerComputerMove(MOVES.ROCK);
+
+      const initialPlayerStorage = localStorage.getItem("playerMoveCounts");
+      const initialComputerStorage = localStorage.getItem("computerMoveCounts");
+
+      expect(JSON.parse(initialPlayerStorage!)).toEqual(playerMoveCounts);
+      expect(JSON.parse(initialComputerStorage!)).toEqual(computerMoveCounts);
 
       model.resetBothMoveCounts();
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -480,9 +480,9 @@ export class Model {
     this.state.history[key] = [];
 
     try {
-      localStorage.setItem(`${key}History`, JSON.stringify([]));
+      localStorage.removeItem(`${key}History`);
     } catch (e) {
-      console.warn(`Failed to save ${key} history to localStorage`, e);
+      console.warn(`Failed to remove ${key} history from localStorage`, e);
     }
   }
 

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -10,11 +10,14 @@ export type MoveData = {
   beats: readonly Move[];
 };
 
+export type MoveCount = Record<StandardMove, number>;
+
 export interface GameState {
   scores: Record<Participant, number>;
   moves: Record<Participant, Move | null>;
   taras: Record<Participant, number>;
   history: Record<Participant, StandardMove[]>;
   mostCommonMove: Record<Participant, StandardMove | null>;
+  moveCounts: Record<Participant, MoveCount>;
   roundNumber: number;
 }


### PR DESCRIPTION
Replaced recalculating the most common move from full history with running tallies stored in moveCounts, reducing computation from O(n) to O(1) for updates and O(1–3) for retrieval.