### PR TITLE
CLEANUP-5: Refine most common move

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -83,14 +83,17 @@ describe("Controller", () => {
     );
   });
 
-  test("initialize does not call view.updateMostCommonMoves when one or both moves are missing", () => {
+  test("initialize calls updateMostCommonMoves when one move is present", () => {
     mockModel.getPlayerMostCommonMove.mockReturnValue(null);
     mockModel.getComputerMostCommonMove.mockReturnValue(MOVES.PAPER);
     mockView.updateMostCommonMoves = jest.fn();
 
     controller.initialize();
 
-    expect(mockView.updateMostCommonMoves).not.toHaveBeenCalled();
+    expect(mockView.updateMostCommonMoves).toHaveBeenCalledWith(
+      null,
+      MOVES.PAPER
+    );
   });
 
   test("endRound calls view.updateMostCommonMoves when both most common moves exist", () => {

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -54,6 +54,7 @@ describe("Controller", () => {
       updateScoreView: jest.fn(),
       updateTaraView: jest.fn(),
       toggleMostCommonMoveTable: jest.fn(),
+      updateMostCommonMoves: jest.fn(),
     };
 
     controller = new Controller(mockModel, mockView);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -30,7 +30,7 @@ export class Controller {
     const playerMostCommonMove = this.model.getPlayerMostCommonMove();
     const comptuterMostCommonMove = this.model.getComputerMostCommonMove();
 
-    if (playerMostCommonMove && comptuterMostCommonMove) {
+    if (playerMostCommonMove || comptuterMostCommonMove) {
       this.view.updateMostCommonMoves(
         playerMostCommonMove,
         comptuterMostCommonMove

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -30,12 +30,10 @@ export class Controller {
     const playerMostCommonMove = this.model.getPlayerMostCommonMove();
     const comptuterMostCommonMove = this.model.getComputerMostCommonMove();
 
-    if (playerMostCommonMove || comptuterMostCommonMove) {
-      this.view.updateMostCommonMoves(
-        playerMostCommonMove,
-        comptuterMostCommonMove
-      );
-    }
+    this.view.updateMostCommonMoves(
+      playerMostCommonMove,
+      comptuterMostCommonMove
+    );
   }
 
   private updateTaraButtonView(): void {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -153,17 +153,24 @@ export class Model {
   private determineMostCommonMove(moveCounts: MoveCount): StandardMove | null {
     let mostCommonMove: StandardMove | null = null;
     let highestCount = 0;
-
-    if (Object.values(moveCounts).every((count) => count === 0)) return null;
+    let tie = false;
 
     for (const [move, count] of Object.entries(moveCounts)) {
       if (count > highestCount) {
         highestCount = count;
         mostCommonMove = move as StandardMove;
+        tie = false;
+      } else if (count === highestCount && count !== 0) {
+        tie = true;
       }
     }
 
-    return mostCommonMove;
+    return tie ? null : mostCommonMove;
+  }
+
+  private resetMostCommonMove(key: Participant): void {
+    this.state.mostCommonMove[key] = null;
+    localStorage.removeItem(`${key}MostCommonMove`);
   }
 
   private setMostCommonMove(key: Participant, moveCounts: MoveCount): void {
@@ -172,12 +179,9 @@ export class Model {
     if (mostCommonMove) {
       this.state.mostCommonMove[key] = mostCommonMove;
       localStorage.setItem(`${key}MostCommonMove`, mostCommonMove.toString());
+    } else {
+      this.resetMostCommonMove(key);
     }
-  }
-
-  private resetMostCommonMove(key: Participant): void {
-    this.state.mostCommonMove[key] = null;
-    localStorage.removeItem(`${key}MostCommonMove`);
   }
 
   private getMostCommonMoveFromStorage(key: Participant): StandardMove | null {
@@ -385,8 +389,8 @@ export class Model {
   showMostCommonMove(): boolean {
     return (
       this.getRoundNumber() > 1 &&
-      !!this.getPlayerMostCommonMove() &&
-      !!this.getComputerMostCommonMove()
+      (this.getPlayerMostCommonMove() !== null ||
+        this.getComputerMostCommonMove() !== null)
     );
   }
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -105,10 +105,13 @@ export class View {
 
   // ===== History Methods =====
 
-  updateMostCommonMoves(player: StandardMove, computer: StandardMove): void {
+  updateMostCommonMoves(
+    player: StandardMove | null,
+    computer: StandardMove | null
+  ): void {
     if (this.playerMostCommonMoveEl)
-      this.playerMostCommonMoveEl.textContent = player;
+      this.playerMostCommonMoveEl.textContent = player ?? "X";
     if (this.computerMostCommonMoveEl)
-      this.computerMostCommonMoveEl.textContent = computer;
+      this.computerMostCommonMoveEl.textContent = computer ?? "X";
   }
 }


### PR DESCRIPTION
Fix tie-handling logic by introducing the tie flag and returning null if a tie exists.

Clear previous data with resetMostCommonMove when there's no most common move.

Handle null safely throughout the controller and view layers.

Improve UI behavior by updating the DOM even when a move is null, using "X" as a clear placeholder.

Expand display logic so the most common move section shows if either value exists, which is more user-friendly.