### PR TITLE
RPST-17: Define Match Data & Persistence

### DIFF
--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -103,6 +103,13 @@ describe("Model", () => {
       removeHistory: jest.fn((participant: Participant) => {
         localStorage.removeItem(`${participant}History`);
       }),
+      getMatch: jest.fn(() => null),
+      setMatch: jest.fn(),
+      getGlobalMatchNumber: jest.fn(() => 1),
+      setGlobalMatchNumber: jest.fn(),
+      removeGlobalMatchNumber: jest.fn(),
+      getOldGlobalRoundNumber: jest.fn(() => null),
+      removeOldGlobalRoundNumber: jest.fn(),
     } as jest.Mocked<IGameStorage>;
     model = new Model(mockGameStorage);
   });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -38,6 +38,8 @@ export class Model {
       computer: { rock: 0, paper: 0, scissors: 0 },
     },
     roundNumber: 1,
+    globalMatchNumber: 1,
+    currentMatch: null,
   };
   private gameStorage: IGameStorage;
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -68,6 +68,8 @@ export class Model {
       PARTICIPANTS.COMPUTER
     );
     this.state.roundNumber = this.gameStorage.getRoundNumber();
+    this.state.globalMatchNumber = this.gameStorage.getGlobalMatchNumber();
+    this.state.currentMatch = this.gameStorage.getMatch();
   }
 
   // ===== General Methods =====

--- a/src/storage/gameStorage.ts
+++ b/src/storage/gameStorage.ts
@@ -1,4 +1,9 @@
-import { Participant, MoveCount, StandardMove } from "../utils/dataObjectUtils";
+import {
+  Match,
+  MoveCount,
+  Participant,
+  StandardMove,
+} from "../utils/dataObjectUtils";
 
 /**
  * Interface for game state storage.
@@ -12,6 +17,9 @@ export interface IGameStorage {
   getMostCommonMove(participant: Participant): StandardMove | null;
   getMoveCounts(participant: Participant): MoveCount;
   getRoundNumber(): number;
+  getGlobalMatchNumber(): number;
+  getMatch(): Match | null;
+  getOldGlobalRoundNumber(): number | null;
 
   // ===== Setters =====
 
@@ -20,6 +28,8 @@ export interface IGameStorage {
   setMostCommonMove(participant: Participant, move: StandardMove | null): void;
   setMoveCounts(participant: Participant, moveCounts: MoveCount): void;
   setRoundNumber(round: number): void;
+  setGlobalMatchNumber(match: number): void;
+  setMatch(match: Match | null): void;
 
   // ===== Removers =====
 
@@ -29,4 +39,6 @@ export interface IGameStorage {
   removeMoveCounts(participant: Participant): void;
   removeRoundNumber(): void;
   removeHistory(participant: Participant): void;
+  removeGlobalMatchNumber(): void;
+  removeOldGlobalRoundNumber(): void;
 }

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -1,5 +1,10 @@
 import { IGameStorage } from "./gameStorage";
-import { Participant, MoveCount, StandardMove } from "../utils/dataObjectUtils";
+import {
+  Match,
+  MoveCount,
+  Participant,
+  StandardMove,
+} from "../utils/dataObjectUtils";
 import { MOVES, STANDARD_MOVE_NAMES } from "../utils/dataUtils";
 
 const KEY_SUFFIX_SCORE = "Score";
@@ -80,6 +85,18 @@ export class LocalStorageGameStorage implements IGameStorage {
     );
   }
 
+  getGlobalMatchNumber(): number {
+    return 1; // temporary default
+  }
+
+  getMatch(): Match | null {
+    return null; // temporary stub
+  }
+
+  getOldGlobalRoundNumber(): number | null {
+    return null; // stub: return null to simulate absence of legacy data
+  }
+
   // ===== Setters =====
 
   setScore(participant: Participant, score: number): void {
@@ -111,6 +128,14 @@ export class LocalStorageGameStorage implements IGameStorage {
     this.safelySetItem(key, round.toString());
   }
 
+  setGlobalMatchNumber(match: number): void {
+    // stub: do nothing for now
+  }
+
+  setMatch(match: Match | null): void {
+    // stub: do nothing for now
+  }
+
   // ===== Removers =====
 
   removeScore(participant: Participant): void {
@@ -140,5 +165,13 @@ export class LocalStorageGameStorage implements IGameStorage {
   removeHistory(participant: Participant): void {
     const key = this.formatKey(participant, KEY_SUFFIX_HISTORY);
     localStorage.removeItem(key);
+  }
+
+  removeGlobalMatchNumber(): void {
+    // stub: do nothing for now
+  }
+
+  removeOldGlobalRoundNumber(): void {
+    // stub: do nothing for now
   }
 }

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -120,7 +120,25 @@ export class LocalStorageGameStorage implements IGameStorage {
   }
 
   getOldGlobalRoundNumber(): number | null {
-    return null; // stub: return null to simulate absence of legacy data
+    const roundString = localStorage.getItem(KEY_ROUND_NUMBER);
+
+    // If the item doesn't exist in localStorage, getItem returns null.
+    if (roundString === null) {
+      return null;
+    }
+
+    // Attempt to parse the string to an integer.
+    const parsedRound = parseInt(roundString, 10);
+
+    // Check if parsing resulted in NaN (Not a Number), meaning the stored value was invalid.
+    if (isNaN(parsedRound)) {
+      console.warn(
+        `Legacy 'roundNumber' in localStorage (${roundString}) is not a valid number. Skipping migration.`
+      );
+      return null; // Treat invalid data as if it doesn't exist for migration purposes
+    }
+
+    return parsedRound;
   }
 
   // ===== Setters =====
@@ -202,6 +220,6 @@ export class LocalStorageGameStorage implements IGameStorage {
   }
 
   removeOldGlobalRoundNumber(): void {
-    // stub: do nothing for now
+    localStorage.removeItem(KEY_ROUND_NUMBER);
   }
 }

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -5,7 +5,12 @@ import {
   Participant,
   StandardMove,
 } from "../utils/dataObjectUtils";
-import { MOVES, STANDARD_MOVE_NAMES } from "../utils/dataUtils";
+import {
+  DAMAGE_PER_LOSS,
+  INITIAL_HEALTH,
+  MOVES,
+  STANDARD_MOVE_NAMES,
+} from "../utils/dataUtils";
 
 const KEY_SUFFIX_SCORE = "Score";
 const KEY_SUFFIX_TARA_COUNT = "TaraCount";
@@ -14,14 +19,25 @@ const KEY_SUFFIX_MOVE_COUNTS = "MoveCounts";
 const KEY_SUFFIX_HISTORY = "History";
 
 const KEY_ROUND_NUMBER = "roundNumber";
+const KEY_GLOBAL_MATCH_NUMBER = "globalMatchNumber";
+const KEY_CURRENT_MATCH = "currentMatch";
 
 const DEFAULT_NUMERIC_VALUE = 0;
 const DEFAULT_ROUND_NUMBER_GET = 1;
+const DEFAULT_MATCH_NUMBER_GET = 1;
 
 const DEFAULT_MOVE_COUNTS: MoveCount = {
   [MOVES.ROCK]: 0,
   [MOVES.PAPER]: 0,
   [MOVES.SCISSORS]: 0,
+};
+
+const DEFAULT_MATCH: Match = {
+  matchRoundNumber: DEFAULT_ROUND_NUMBER_GET,
+  playerHealth: INITIAL_HEALTH,
+  computerHealth: INITIAL_HEALTH,
+  initialHealth: INITIAL_HEALTH,
+  damagePerLoss: DAMAGE_PER_LOSS,
 };
 
 /**
@@ -86,11 +102,21 @@ export class LocalStorageGameStorage implements IGameStorage {
   }
 
   getGlobalMatchNumber(): number {
-    return 1; // temporary default
+    return parseInt(
+      localStorage.getItem(KEY_ROUND_NUMBER) ||
+        DEFAULT_MATCH_NUMBER_GET.toString(),
+      10
+    );
   }
 
   getMatch(): Match | null {
-    return null; // temporary stub
+    try {
+      const raw = localStorage.getItem(KEY_CURRENT_MATCH);
+      return raw ? JSON.parse(raw) : DEFAULT_MATCH;
+    } catch (e) {
+      console.warn(`LocalStorage Error: Failed to parse currentMatch.`, e);
+      return DEFAULT_MATCH;
+    }
   }
 
   getOldGlobalRoundNumber(): number | null {
@@ -128,12 +154,16 @@ export class LocalStorageGameStorage implements IGameStorage {
     this.safelySetItem(key, round.toString());
   }
 
-  setGlobalMatchNumber(match: number): void {
-    // stub: do nothing for now
+  setGlobalMatchNumber(matchNumber: number): void {
+    this.safelySetItem(KEY_GLOBAL_MATCH_NUMBER, matchNumber.toString());
   }
 
   setMatch(match: Match | null): void {
-    // stub: do nothing for now
+    if (match) {
+      this.safelySetItem(KEY_CURRENT_MATCH, JSON.stringify(match));
+    } else {
+      localStorage.removeItem(KEY_CURRENT_MATCH);
+    }
   }
 
   // ===== Removers =====
@@ -168,7 +198,7 @@ export class LocalStorageGameStorage implements IGameStorage {
   }
 
   removeGlobalMatchNumber(): void {
-    // stub: do nothing for now
+    localStorage.removeItem(KEY_GLOBAL_MATCH_NUMBER);
   }
 
   removeOldGlobalRoundNumber(): void {

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -103,7 +103,7 @@ export class LocalStorageGameStorage implements IGameStorage {
 
   getGlobalMatchNumber(): number {
     return parseInt(
-      localStorage.getItem(KEY_ROUND_NUMBER) ||
+      localStorage.getItem(KEY_GLOBAL_MATCH_NUMBER) ||
         DEFAULT_MATCH_NUMBER_GET.toString(),
       10
     );
@@ -112,10 +112,10 @@ export class LocalStorageGameStorage implements IGameStorage {
   getMatch(): Match | null {
     try {
       const raw = localStorage.getItem(KEY_CURRENT_MATCH);
-      return raw ? JSON.parse(raw) : DEFAULT_MATCH;
+      return raw ? JSON.parse(raw) : null;
     } catch (e) {
       console.warn(`LocalStorage Error: Failed to parse currentMatch.`, e);
-      return DEFAULT_MATCH;
+      return null;
     }
   }
 

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -12,6 +12,14 @@ export type MoveData = {
 
 export type MoveCount = Record<StandardMove, number>;
 
+export interface Match {
+  matchRoundNumber: number;
+  playerHealth: number;
+  computerHealth: number;
+  initialHealth: number;
+  damagePerLoss: number;
+}
+
 export interface GameState {
   scores: Record<Participant, number>;
   moves: Record<Participant, Move | null>;
@@ -19,12 +27,6 @@ export interface GameState {
   mostCommonMove: Record<Participant, StandardMove | null>;
   moveCounts: Record<Participant, MoveCount>;
   roundNumber: number;
-}
-
-export interface Match {
-  matchRoundNumber: number;
-  playerHealth: number;
-  computerHealth: number;
-  initialHealth: number;
-  damagePerLoss: number;
+  globalMatchNumber: number;
+  currentMatch: Match | null;
 }

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -20,3 +20,11 @@ export interface GameState {
   moveCounts: Record<Participant, MoveCount>;
   roundNumber: number;
 }
+
+export interface Match {
+  matchRoundNumber: number;
+  playerHealth: number;
+  computerHealth: number;
+  initialHealth: number;
+  damagePerLoss: number;
+}

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -5,6 +5,9 @@ export const PARTICIPANTS = {
   COMPUTER: "computer",
 } as const;
 
+export const INITIAL_HEALTH = 100;
+export const DAMAGE_PER_LOSS = 50;
+
 export const MOVES = {
   ROCK: "rock",
   PAPER: "paper",


### PR DESCRIPTION
**Summary**: Define Match data structure, update global game state, and implement its persistence.

**Description**: Focuses on establishing the core data structure for a game match, including health and round tracking within the match. It also updates the overall global game state to include a `globalMatchNumber` and ensures all game data can be reliably saved to and loaded from `localStorage`, while preparing for backward compatibility with older `roundNumber` storage.

Acceptance Criteria:
1. A new `Match` interface is defined in `utils/dataObjectUtils.ts`.
2. `utils/dataUtils.ts` includes constants `INITIAL_HEALTH` and `DAMAGE_PER_LOSS` for default values.
3. The `Model `class's `state` property is updated `currentMatch` and `globalMatchNumber`.
4. The `IGameStorage` interface (`in storage/gameStorage.ts`) includes new and updated methods.
5. The `LocalStorageGameStorage` class implements all new and updated `IGameStorage` methods.
6. (Manual Test) After implementing, verify that creating and saving a `Match` object results in correct data in `localStorage`, and that refreshing the page loads that data back into the Model. Confirm `globalMatchNumber` is stored/retrieved correctly.