### PR TITLE
RPST-18: Game State Initialization & Migration

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -31,7 +31,6 @@ describe("Controller", () => {
       resetMoves: jest.fn(),
       resetScores: jest.fn(),
       resetTaras: jest.fn(),
-      resetRoundNumber: jest.fn(),
       registerPlayerMove: jest.fn(),
       resetHistories: jest.fn(),
       resetBothMoveCounts: jest.fn(),
@@ -184,7 +183,6 @@ describe("Controller", () => {
     expect(mockModel.resetScores).toHaveBeenCalled();
     expect(mockModel.resetMoves).toHaveBeenCalled();
     expect(mockModel.resetTaras).toHaveBeenCalled();
-    expect(mockModel.resetRoundNumber).toHaveBeenCalled();
     expect(mockModel.resetHistories).toHaveBeenCalled();
     expect(mockModel.resetBothMoveCounts).toHaveBeenCalled();
     expect(mockModel.resetMostCommonMoves).toHaveBeenCalled();

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -75,7 +75,6 @@ export class Controller {
     this.model.resetScores();
     this.model.resetMoves();
     this.model.resetTaras();
-    this.model.resetRoundNumber();
     this.model.resetHistories();
     this.model.resetBothMoveCounts();
     this.model.resetMostCommonMoves();

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -917,4 +917,27 @@ describe("Model", () => {
       expect(mockGameStorage.setGlobalMatchNumber).not.toHaveBeenCalled();
     });
   });
+
+  describe("isMatchActive", () => {
+    test("returns false if currentMatch is null", () => {
+      const model = new Model(mockGameStorage);
+      expect(model.isMatchActive()).toBe(false);
+    });
+
+    test("returns true if currentMatch is a valid Match object", () => {
+      const validMatch: Match = {
+        matchRoundNumber: 1,
+        playerHealth: 100,
+        computerHealth: 50,
+        initialHealth: 100,
+        damagePerLoss: 50,
+      };
+
+      // Override getMatch to return a real match
+      mockGameStorage.getMatch.mockReturnValue(validMatch);
+
+      const model = new Model(mockGameStorage);
+      expect(model.isMatchActive()).toBe(true);
+    });
+  });
 });

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -95,14 +95,6 @@ describe("Model", () => {
       removeMoveCounts: jest.fn((participant: Participant) => {
         localStorage.removeItem(`${participant}MoveCounts`);
       }),
-      getRoundNumber: jest.fn(() => {
-        const stored = localStorage.getItem(`roundNumber`);
-        return parseInt(stored || "1", 10);
-      }),
-      setRoundNumber: jest.fn((roundNumber: number) => {
-        localStorage.setItem("roundNumber", roundNumber.toString());
-      }),
-      removeRoundNumber: jest.fn(),
       removeHistory: jest.fn((participant: Participant) => {
         localStorage.removeItem(`${participant}History`);
       }),
@@ -208,16 +200,40 @@ describe("Model", () => {
       expect(model.getRoundNumber()).toBe(1);
     });
 
-    test("setRoundNumber updates the state and localStorage", () => {
+    test("setRoundNumber updates the matchRoundNumber in state and storage", () => {
+      mockGameStorage.getMatch.mockReturnValue({
+        matchRoundNumber: 1,
+        playerHealth: INITIAL_HEALTH,
+        computerHealth: INITIAL_HEALTH,
+        initialHealth: INITIAL_HEALTH,
+        damagePerLoss: DAMAGE_PER_LOSS,
+      });
+
+      const model = new Model(mockGameStorage);
       model.setRoundNumber(3);
+
       expect(model.getRoundNumber()).toBe(3);
-      expect(localStorage.getItem("roundNumber")).toBe("3");
+      expect(mockGameStorage.setMatch).toHaveBeenCalledWith(
+        expect.objectContaining({ matchRoundNumber: 3 })
+      );
     });
 
-    test("increaseRoundNumber increments the round number by 1", () => {
-      model.setRoundNumber(2);
+    test("increaseRoundNumber increments the matchRoundNumber by 1", () => {
+      mockGameStorage.getMatch.mockReturnValue({
+        matchRoundNumber: 2,
+        playerHealth: INITIAL_HEALTH,
+        computerHealth: INITIAL_HEALTH,
+        initialHealth: INITIAL_HEALTH,
+        damagePerLoss: DAMAGE_PER_LOSS,
+      });
+
+      const model = new Model(mockGameStorage);
       model.increaseRoundNumber();
+
       expect(model.getRoundNumber()).toBe(3);
+      expect(mockGameStorage.setMatch).toHaveBeenCalledWith(
+        expect.objectContaining({ matchRoundNumber: 3 })
+      );
     });
   });
 
@@ -385,12 +401,6 @@ describe("Model", () => {
       model.resetScores();
       expect(model.getPlayerScore()).toBe(0);
       expect(model.getComputerScore()).toBe(0);
-    });
-
-    test("resetRoundNumber should set round number to 1", () => {
-      model.setRoundNumber(5);
-      model.resetRoundNumber();
-      expect(model.getRoundNumber()).toBe(1);
     });
 
     test("resetTaras should set both player and computer Tara counts to 0", () => {
@@ -870,8 +880,6 @@ describe("Model Constructor - Initialization and Migration", () => {
       removeMoveCounts: jest.fn((participant: Participant) => {}),
 
       getRoundNumber: jest.fn(() => 1),
-      setRoundNumber: jest.fn(),
-      removeRoundNumber: jest.fn(),
       removeHistory: jest.fn((participant: Participant) => {}),
 
       getMatch: jest.fn(() => null),

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -109,6 +109,10 @@ export class Model {
     }
   }
 
+  isMatchActive(): boolean {
+    return this.state.currentMatch !== null;
+  }
+
   // ===== Score Methods =====
 
   private setScore(key: Participant, value: number): void {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -39,7 +39,6 @@ export class Model {
       player: { rock: 0, paper: 0, scissors: 0 },
       computer: { rock: 0, paper: 0, scissors: 0 },
     },
-    roundNumber: 1,
     globalMatchNumber: 1,
     currentMatch: null,
   };
@@ -387,21 +386,19 @@ export class Model {
   // ===== Round Methods =====
 
   getRoundNumber(): number {
-    return this.state.roundNumber;
+    return this.state.currentMatch?.matchRoundNumber ?? 1;
   }
 
   setRoundNumber(value: number): void {
-    this.state.roundNumber = value;
-    this.gameStorage.setRoundNumber(value);
+    if (!this.state.currentMatch) return;
+
+    this.state.currentMatch.matchRoundNumber = value;
+    this.gameStorage.setMatch(this.state.currentMatch);
   }
 
   increaseRoundNumber(): void {
-    this.setRoundNumber(this.getRoundNumber() + 1);
-  }
-
-  resetRoundNumber(): void {
-    this.state.roundNumber = 1;
-    this.gameStorage.removeRoundNumber();
+    const current = this.getRoundNumber();
+    this.setRoundNumber(current + 1);
   }
 
   // ===== Tara Methods =====

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -7,6 +7,8 @@ import {
 } from "../utils/dataObjectUtils";
 import {
   ALL_MOVE_NAMES,
+  DAMAGE_PER_LOSS,
+  INITIAL_HEALTH,
   MOVES,
   MOVE_DATA_MAP,
   PARTICIPANTS,
@@ -45,6 +47,7 @@ export class Model {
 
   constructor(gameStorage: IGameStorage = new LocalStorageGameStorage()) {
     this.gameStorage = gameStorage;
+
     this.state.scores.player = this.gameStorage.getScore(PARTICIPANTS.PLAYER);
     this.state.scores.computer = this.gameStorage.getScore(
       PARTICIPANTS.COMPUTER
@@ -67,9 +70,8 @@ export class Model {
     this.state.moveCounts.computer = this.gameStorage.getMoveCounts(
       PARTICIPANTS.COMPUTER
     );
-    this.state.roundNumber = this.gameStorage.getRoundNumber();
-    this.state.globalMatchNumber = this.gameStorage.getGlobalMatchNumber();
-    this.state.currentMatch = this.gameStorage.getMatch();
+
+    this._loadOrMigrateMatchState();
   }
 
   // ===== General Methods =====
@@ -458,4 +460,71 @@ export class Model {
   taraIsEnabled(): boolean {
     return this.getTaraCount(PARTICIPANTS.PLAYER) > 0;
   }
+
+  // ===== Match Methods =====
+
+  /**
+   * Initializes the game state based on available storage.
+   *
+   * This method is called during Model construction. It checks for:
+   * - A valid saved match (loads it and skips migration),
+   * - An old-format global round number (migrates it into a new match),
+   * - Or no valid data (starts a new match with default values).
+   *
+   * It also ensures the global match number is set appropriately.
+   */
+  private _loadOrMigrateMatchState(): void {
+    this.state.currentMatch = this.gameStorage.getMatch();
+
+    if (this.isMatchActive()) {
+      this._loadExistingMatchState();
+    } else {
+      const oldGlobalRoundNumber = this.gameStorage.getOldGlobalRoundNumber();
+
+      if (oldGlobalRoundNumber !== null && oldGlobalRoundNumber > 0) {
+        this._migrateOldData(oldGlobalRoundNumber);
+      } else {
+        this._startNewGameDefaults();
+      }
+    }
+  }
+
+  /**
+   * Loads state for an existing match stored in the new format.
+   */
+  private _loadExistingMatchState(): void {
+    this.state.globalMatchNumber = this.gameStorage.getGlobalMatchNumber();
+  }
+
+  /**
+   * Migrates match state from an older game version to the current format.
+   *
+   * @param oldRoundNumber - The round number from the old game format.
+   */
+  private _migrateOldData(oldRoundNumber: number): void {
+    this.state.currentMatch = {
+      matchRoundNumber: oldRoundNumber,
+      playerHealth: INITIAL_HEALTH,
+      computerHealth: INITIAL_HEALTH,
+      initialHealth: INITIAL_HEALTH,
+      damagePerLoss: DAMAGE_PER_LOSS,
+    };
+
+    this.gameStorage.setMatch(this.state.currentMatch);
+    this.gameStorage.removeOldGlobalRoundNumber();
+
+    this.state.globalMatchNumber = 1;
+    this.gameStorage.setGlobalMatchNumber(this.state.globalMatchNumber);
+  }
+
+  /**
+   * Initializes state for a completely new game with no saved data.
+   */
+  private _startNewGameDefaults(): void {
+    this.state.currentMatch = null;
+    this.state.globalMatchNumber = 1;
+    this.gameStorage.setGlobalMatchNumber(this.state.globalMatchNumber);
+  }
+
+  // ===== END OF CLASS =====
 }

--- a/src/storage/gameStorage.ts
+++ b/src/storage/gameStorage.ts
@@ -16,7 +16,6 @@ export interface IGameStorage {
   getTaraCount(participant: Participant): number;
   getMostCommonMove(participant: Participant): StandardMove | null;
   getMoveCounts(participant: Participant): MoveCount;
-  getRoundNumber(): number;
   getGlobalMatchNumber(): number;
   getMatch(): Match | null;
   getOldGlobalRoundNumber(): number | null;
@@ -27,7 +26,6 @@ export interface IGameStorage {
   setTaraCount(participant: Participant, count: number): void;
   setMostCommonMove(participant: Participant, move: StandardMove | null): void;
   setMoveCounts(participant: Participant, moveCounts: MoveCount): void;
-  setRoundNumber(round: number): void;
   setGlobalMatchNumber(match: number): void;
   setMatch(match: Match | null): void;
 
@@ -37,7 +35,6 @@ export interface IGameStorage {
   removeTaraCount(participant: Participant): void;
   removeMostCommonMove(participant: Participant): void;
   removeMoveCounts(participant: Participant): void;
-  removeRoundNumber(): void;
   removeHistory(participant: Participant): void;
   removeGlobalMatchNumber(): void;
   removeOldGlobalRoundNumber(): void;

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -5,12 +5,7 @@ import {
   Participant,
   StandardMove,
 } from "../utils/dataObjectUtils";
-import {
-  DAMAGE_PER_LOSS,
-  INITIAL_HEALTH,
-  MOVES,
-  STANDARD_MOVE_NAMES,
-} from "../utils/dataUtils";
+import { MOVES, STANDARD_MOVE_NAMES } from "../utils/dataUtils";
 
 const KEY_SUFFIX_SCORE = "Score";
 const KEY_SUFFIX_TARA_COUNT = "TaraCount";
@@ -30,14 +25,6 @@ const DEFAULT_MOVE_COUNTS: MoveCount = {
   [MOVES.ROCK]: 0,
   [MOVES.PAPER]: 0,
   [MOVES.SCISSORS]: 0,
-};
-
-const DEFAULT_MATCH: Match = {
-  matchRoundNumber: DEFAULT_ROUND_NUMBER_GET,
-  playerHealth: INITIAL_HEALTH,
-  computerHealth: INITIAL_HEALTH,
-  initialHealth: INITIAL_HEALTH,
-  damagePerLoss: DAMAGE_PER_LOSS,
 };
 
 /**

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -18,7 +18,6 @@ const KEY_GLOBAL_MATCH_NUMBER = "globalMatchNumber";
 const KEY_CURRENT_MATCH = "currentMatch";
 
 const DEFAULT_NUMERIC_VALUE = 0;
-const DEFAULT_ROUND_NUMBER_GET = 1;
 const DEFAULT_MATCH_NUMBER_GET = 1;
 
 const DEFAULT_MOVE_COUNTS: MoveCount = {
@@ -78,14 +77,6 @@ export class LocalStorageGameStorage implements IGameStorage {
       console.warn(`LocalStorage Error: Failed to parse "${key}".`, e);
       return DEFAULT_MOVE_COUNTS;
     }
-  }
-
-  getRoundNumber(): number {
-    return parseInt(
-      localStorage.getItem(KEY_ROUND_NUMBER) ||
-        DEFAULT_ROUND_NUMBER_GET.toString(),
-      10
-    );
   }
 
   getGlobalMatchNumber(): number {
@@ -154,11 +145,6 @@ export class LocalStorageGameStorage implements IGameStorage {
     this.safelySetItem(key, JSON.stringify(moveCounts));
   }
 
-  setRoundNumber(round: number): void {
-    const key = KEY_ROUND_NUMBER;
-    this.safelySetItem(key, round.toString());
-  }
-
   setGlobalMatchNumber(matchNumber: number): void {
     this.safelySetItem(KEY_GLOBAL_MATCH_NUMBER, matchNumber.toString());
   }
@@ -191,10 +177,6 @@ export class LocalStorageGameStorage implements IGameStorage {
   removeMoveCounts(participant: Participant): void {
     const key = this.formatKey(participant, KEY_SUFFIX_MOVE_COUNTS);
     localStorage.removeItem(key);
-  }
-
-  removeRoundNumber(): void {
-    localStorage.removeItem(KEY_ROUND_NUMBER);
   }
 
   removeHistory(participant: Participant): void {

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -26,7 +26,6 @@ export interface GameState {
   taras: Record<Participant, number>;
   mostCommonMove: Record<Participant, StandardMove | null>;
   moveCounts: Record<Participant, MoveCount>;
-  roundNumber: number;
   globalMatchNumber: number;
   currentMatch: Match | null;
 }


### PR DESCRIPTION
**feat: Implement core game state loading & match migration logic**

Introduces a significant refactor to the `Model` constructor, establishing a robust and comprehensive system for loading game state and handling match persistence.

Previously, game state initialization was rudimentary. This update enables the application to:

* **Load Existing State:** Correctly load all global scores, Tara counts, move histories, and most importantly, the `currentMatch` object from storage.
* **Migrate Legacy Data:** Seamlessly migrate `oldGlobalRoundNumber` data from previous versions into the new `currentMatch` format, ensuring continuity for returning players. If a legacy round number is found, a new `Match` object is created and persisted, and the old key is removed.
* **Initialize New Games:** Properly set up a clean, default state for brand new players with no existing data.
* **Check Active Match Status:** A new public getter, `Model.isMatchActive()`, is added to provide a clear way to determine if a game is currently in progress.

This foundational work significantly improves data persistence and ensures a smooth user experience across different game states and version updates.

**Acceptance Criteria Met:**

* **AC1 (Core Logic):** Refactored `Model` constructor to handle loading `currentMatch`, migrating `oldGlobalRoundNumber` (if present), or initializing a new game with defaults. This includes appropriate calls to `gameStorage.getMatch()`, `gameStorage.getOldGlobalRoundNumber()`, `gameStorage.removeOldGlobalRoundNumber()`, `gameStorage.setMatch()`, `gameStorage.setGlobalMatchNumber()`, and other `gameStorage` methods for non-match-specific state.
* **AC2 (Prerequisite for checking model.isMatchActive()):** Added `public isMatchActive(): boolean { return this.state.currentMatch !== null; }` to `src/model.ts`.
* **AC3 The game's current round display and calculation logic is updated** to derive from `currentMatch.matchRoundNumber`.