### PR TITLE
RPST-20: Implement Core Match Logic: Health, Endings, and Progression

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -38,6 +38,7 @@ describe("Controller", () => {
       getPlayerMostCommonMove: jest.fn(),
       getComputerMostCommonMove: jest.fn(),
       isMatchActive: jest.fn(),
+      isMatchOver: jest.fn(),
       resetMatchData: jest.fn(),
     };
 

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -1,5 +1,6 @@
 import { Controller } from "./controller";
-import { MOVES } from "../utils/dataUtils";
+import { MOVES, PARTICIPANTS } from "../utils/dataUtils";
+import { Move } from "../utils/dataObjectUtils";
 
 describe("Controller", () => {
   let mockModel: any;
@@ -28,6 +29,7 @@ describe("Controller", () => {
       getPlayerTaraCount: jest.fn().mockReturnValue(0),
       getComputerTaraCount: jest.fn().mockReturnValue(0),
       taraIsEnabled: jest.fn(),
+      isTaraButtonVisible: jest.fn(),
       resetMoves: jest.fn(),
       resetScores: jest.fn(),
       resetTaras: jest.fn(),
@@ -37,14 +39,24 @@ describe("Controller", () => {
       resetMostCommonMoves: jest.fn(),
       getPlayerMostCommonMove: jest.fn(),
       getComputerMostCommonMove: jest.fn(),
+      showMostCommonMove: jest.fn(),
       isMatchActive: jest.fn(),
       isMatchOver: jest.fn(),
+      setMatch: jest.fn(),
       resetMatchData: jest.fn(),
+      getRoundNumber: jest.fn(),
+      updateRound: jest.fn(),
+      incrementMatchNumber: jest.fn(),
+      getMatchWinner: jest.fn(),
+      getMatchNumber: jest.fn(),
+      setDefaultMatchData: jest.fn(),
     };
 
     mockView = {
       updateMessage: jest.fn(),
       updateScores: jest.fn(),
+      updateRound: jest.fn(),
+      updateMatch: jest.fn(),
       showRoundOutcome: jest.fn(),
       toggleMoveButtons: jest.fn(),
       togglePlayAgain: jest.fn(),
@@ -58,6 +70,8 @@ describe("Controller", () => {
       toggleMostCommonMoveTable: jest.fn(),
       updateMostCommonMoves: jest.fn(),
       updateStartButton: jest.fn(),
+      showMatchOutcome: jest.fn(),
+      toggleTaraButton: jest.fn(),
     };
 
     controller = new Controller(mockModel, mockView);
@@ -194,5 +208,152 @@ describe("Controller", () => {
     expect((controller as any).updateScoreView).toHaveBeenCalled();
     expect((controller as any).updateTaraView).toHaveBeenCalled();
     expect((controller as any).updateTaraButtonView).toHaveBeenCalled();
+  });
+
+  test("startGame performs initial game setup with correct view updates", () => {
+    const initialRoundNumber = 1;
+    const initialMatchNumber = 1;
+    const showMostCommonMove = true; // Example value
+
+    mockModel.getRoundNumber.mockReturnValue(initialRoundNumber);
+    mockModel.getMatchNumber.mockReturnValue(initialMatchNumber);
+    mockModel.showMostCommonMove.mockReturnValue(showMostCommonMove);
+    mockModel.setDefaultMatchData.mockImplementation(() => {});
+
+    // Mock all view methods that startGame interacts with
+    mockView.updateRound.mockImplementation(() => {});
+    mockView.updateMatch.mockImplementation(() => {});
+    mockView.toggleStartButton.mockImplementation(() => {});
+    mockView.toggleResetGameState.mockImplementation(() => {});
+    mockView.toggleMostCommonMoveTable.mockImplementation(() => {});
+    mockView.toggleMoveButtons.mockImplementation(() => {});
+
+    controller["startGame"]();
+
+    // Expected assertions
+    expect(mockModel.setDefaultMatchData).toHaveBeenCalled();
+    expect(mockView.updateRound).toHaveBeenCalledWith(initialRoundNumber);
+    expect(mockView.updateMatch).toHaveBeenCalledWith(initialMatchNumber);
+    expect(mockView.toggleStartButton).toHaveBeenCalledWith(false);
+    expect(mockView.toggleResetGameState).toHaveBeenCalledWith(false);
+    expect(mockView.toggleMostCommonMoveTable).toHaveBeenCalledWith(
+      showMostCommonMove
+    );
+    expect(mockView.toggleMoveButtons).toHaveBeenCalledWith(true);
+  });
+
+  describe("endRound", () => {
+    test("endRound should proceed to next round if match is not over", () => {
+      mockModel.getPlayerMove.mockReturnValue("rock");
+      mockModel.getComputerMove.mockReturnValue("scissors");
+      mockModel.evaluateRound.mockReturnValue("You win the round!");
+      mockModel.isMatchOver.mockReturnValue(false);
+      mockModel.increaseRoundNumber.mockImplementation(() => {});
+      mockModel.getRoundNumber.mockReturnValue(2);
+
+      controller["endRound"]();
+
+      expect(mockView.showRoundOutcome).toHaveBeenCalledWith(
+        "rock",
+        "scissors",
+        "You win the round!"
+      );
+      expect(mockModel.increaseRoundNumber).toHaveBeenCalled();
+      expect(mockModel.incrementMatchNumber).not.toHaveBeenCalled();
+      expect(mockModel.setMatch).not.toHaveBeenCalled();
+      expect(mockView.showMatchOutcome).not.toHaveBeenCalled();
+    });
+
+    test("endRound should show match outcome and increment match number if match is over", () => {
+      mockModel.getPlayerMove.mockReturnValue("rock");
+      mockModel.getComputerMove.mockReturnValue("scissors");
+      mockModel.isMatchOver.mockReturnValue(true);
+      mockModel.getMatchWinner.mockReturnValue(PARTICIPANTS.PLAYER);
+      mockModel.incrementMatchNumber.mockImplementation(() => {});
+      mockModel.setMatch.mockImplementation(() => {});
+      mockModel.increaseRoundNumber.mockImplementation(() => {});
+
+      controller["endRound"]();
+
+      expect(mockView.showMatchOutcome).toHaveBeenCalledWith(
+        "rock",
+        "scissors",
+        PARTICIPANTS.PLAYER
+      );
+      expect(mockModel.incrementMatchNumber).toHaveBeenCalled();
+      expect(mockModel.setMatch).toHaveBeenCalledWith(null);
+      expect(mockView.showRoundOutcome).not.toHaveBeenCalled();
+      expect(mockModel.increaseRoundNumber).not.toHaveBeenCalled();
+    });
+
+    test("endRound should show match outcome and increment match number if computer wins match", () => {
+      const playerMove: Move = "paper";
+      const computerMove: Move = "scissors"; // Computer wins round, leading to match win
+      const matchWinner = PARTICIPANTS.COMPUTER;
+
+      mockModel.getPlayerMove.mockReturnValue(playerMove);
+      mockModel.getComputerMove.mockReturnValue(computerMove);
+      // evaluateRound might not be called if match is already detected as over by health
+      // but good practice to mock it if it theoretically could be.
+      mockModel.evaluateRound.mockReturnValue("Computer wins the round!");
+      mockModel.isMatchOver.mockReturnValue(true); // Key for this test
+      mockModel.getMatchWinner.mockReturnValue(matchWinner); // Key for this test
+      mockModel.incrementMatchNumber.mockImplementation(() => {});
+      mockModel.setMatch.mockImplementation(() => {}); // Set to null after match end
+
+      // Mock common view/model updates that happen at the end of every round
+      mockModel.getPlayerScore.mockReturnValue(0);
+      mockModel.getComputerScore.mockReturnValue(1); // Example score for computer win
+      mockModel.getPlayerTaraCount.mockReturnValue(0);
+      mockModel.getComputerTaraCount.mockReturnValue(3);
+      mockModel.getPlayerMostCommonMove.mockReturnValue(null);
+      mockModel.getComputerMostCommonMove.mockReturnValue("scissors");
+      mockModel.isTaraButtonVisible.mockReturnValue(false);
+
+      controller["endRound"](); // Accessing private method for testing
+
+      // Assertions for when match IS over (Computer wins)
+      expect(mockView.showMatchOutcome).toHaveBeenCalledWith(
+        playerMove,
+        computerMove,
+        matchWinner
+      );
+      expect(mockModel.incrementMatchNumber).toHaveBeenCalled();
+      expect(mockModel.setMatch).toHaveBeenCalledWith(null); // Should be called with null
+      expect(mockView.showRoundOutcome).not.toHaveBeenCalled(); // Should NOT be called
+      expect(mockModel.increaseRoundNumber).not.toHaveBeenCalled(); // Should NOT be called
+
+      // Common calls for end of round (regardless of match end)
+      expect(mockView.toggleMostCommonMoveTable).toHaveBeenCalledWith(false);
+      expect(mockView.toggleMoveButtons).toHaveBeenCalledWith(false);
+      expect(mockView.togglePlayAgain).toHaveBeenCalledWith(true);
+      expect(mockView.updateScores).toHaveBeenCalledWith(0, 1);
+      expect(mockView.updateTaraCounts).toHaveBeenCalledWith(0, 3);
+      expect(mockView.updateMostCommonMoves).toHaveBeenCalledWith(
+        null,
+        "scissors"
+      );
+    });
+  });
+
+  describe("handleNextRound", () => {
+    test("prepares for the next round within a match", () => {
+      const nextRoundNumber = 3;
+      const currentMatchNumber = 1;
+
+      mockModel.getRoundNumber.mockReturnValue(nextRoundNumber);
+      mockModel.getMatchNumber.mockReturnValue(currentMatchNumber);
+      mockModel.setDefaultMatchData.mockImplementation(() => {});
+      mockView.updateRound.mockImplementation(() => {});
+      mockView.updateMatch.mockImplementation(() => {});
+      mockView.resetForNextRound.mockImplementation(() => {});
+
+      controller["handleNextRound"]();
+
+      expect(mockModel.setDefaultMatchData).toHaveBeenCalled();
+      expect(mockView.updateRound).toHaveBeenCalledWith(nextRoundNumber);
+      expect(mockView.updateMatch).toHaveBeenCalledWith(currentMatchNumber);
+      expect(mockView.resetForNextRound).toHaveBeenCalled();
+    });
   });
 });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -27,12 +27,9 @@ export class Controller {
   }
 
   private updateMostCommonMoveView(): void {
-    const playerMostCommonMove = this.model.getPlayerMostCommonMove();
-    const comptuterMostCommonMove = this.model.getComputerMostCommonMove();
-
     this.view.updateMostCommonMoves(
-      playerMostCommonMove,
-      comptuterMostCommonMove
+      this.model.getPlayerMostCommonMove(),
+      this.model.getComputerMostCommonMove()
     );
   }
 
@@ -48,24 +45,33 @@ export class Controller {
     const showMostCommonMove = this.model.showMostCommonMove();
 
     this.model.setDefaultMatchData();
+    this.view.updateRound(roundNumber);
+    this.view.updateMatch(matchNumber);
     this.view.toggleStartButton(false);
     this.view.toggleResetGameState(false);
     this.view.toggleMostCommonMoveTable(showMostCommonMove);
     this.view.toggleMoveButtons(true);
-    this.view.updateRound(roundNumber);
-    this.view.updateMatch(matchNumber);
   }
 
   private endRound(): void {
     const playerMove = this.model.getPlayerMove();
     const computerMove = this.model.getComputerMove();
     const result = this.model.evaluateRound();
+    const isMatchOver = this.model.isMatchOver();
 
-    this.view.showRoundOutcome(playerMove, computerMove, result);
+    if (isMatchOver) {
+      const winner = this.model.getMatchWinner();
+      this.view.showMatchOutcome(playerMove, computerMove, winner);
+      this.model.incrementMatchNumber();
+      this.model.setMatch(null);
+    } else {
+      this.view.showRoundOutcome(playerMove, computerMove, result);
+      this.model.increaseRoundNumber();
+    }
+
     this.view.toggleMostCommonMoveTable(false);
     this.view.toggleMoveButtons(false);
     this.view.togglePlayAgain(true);
-    this.model.increaseRoundNumber();
     this.updateScoreView();
     this.updateTaraView();
     this.updateMostCommonMoveView();
@@ -73,7 +79,13 @@ export class Controller {
   }
 
   private handleNextRound(): void {
-    this.view.updateRound(this.model.getRoundNumber());
+    this.model.setDefaultMatchData();
+
+    const roundNumber = this.model.getRoundNumber();
+    const matchNumber = this.model.getMatchNumber();
+
+    this.view.updateRound(roundNumber);
+    this.view.updateMatch(matchNumber);
     this.view.resetForNextRound();
   }
 

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -178,20 +178,20 @@ describe("Model", () => {
       expect(model.getComputerScore()).toBe(0);
     });
 
-    test("returns 'You win!' if player beats computer and updates score", () => {
+    test("returns 'You win the round!' if player beats computer and updates score", () => {
       model.setPlayerMove(MOVES.ROCK);
       model.setComputerMove(MOVES.SCISSORS);
 
-      expect(model.evaluateRound()).toBe("You win!");
+      expect(model.evaluateRound()).toBe("You win the round!");
       expect(model.getPlayerScore()).toBe(1);
       expect(model.getComputerScore()).toBe(0);
     });
 
-    test("returns 'Computer wins!' if computer beats player and updates score", () => {
+    test("returns 'Computer wins the round!' if computer beats player and updates score", () => {
       model.setPlayerMove(MOVES.PAPER);
       model.setComputerMove(MOVES.SCISSORS);
 
-      expect(model.evaluateRound()).toBe("Computer wins!");
+      expect(model.evaluateRound()).toBe("Computer wins the round!");
       expect(model.getComputerScore()).toBe(1);
       expect(model.getPlayerScore()).toBe(0);
     });
@@ -287,7 +287,7 @@ describe("Model", () => {
       for (const move of STANDARD_MOVE_DATA_MAP.keys()) {
         model.setPlayerMove(MOVES.TARA);
         model.setComputerMove(move);
-        expect(model.evaluateRound()).toBe("You win!");
+        expect(model.evaluateRound()).toBe("You win the round!");
       }
     });
 
@@ -295,7 +295,7 @@ describe("Model", () => {
       for (const move of STANDARD_MOVE_DATA_MAP.keys()) {
         model.setPlayerMove(move);
         model.setComputerMove(MOVES.TARA);
-        expect(model.evaluateRound()).toBe("Computer wins!");
+        expect(model.evaluateRound()).toBe("Computer wins the round!");
       }
     });
 

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -1,4 +1,4 @@
-import { MOVES, PARTICIPANTS } from "./dataUtils";
+import { HEALTH_KEYS, MOVES, PARTICIPANTS } from "./dataUtils";
 
 export type Move = (typeof MOVES)[keyof typeof MOVES];
 export type StandardMove = Exclude<Move, "tara">;

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -18,6 +18,11 @@ export const DEFAULT_MATCH: Match = {
   damagePerLoss: DAMAGE_PER_LOSS,
 };
 
+export const HEALTH_KEYS = {
+  player: "playerHealth",
+  computer: "computerHealth",
+} as const;
+
 export const MOVES = {
   ROCK: "rock",
   PAPER: "paper",

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,4 @@
-import { Move, StandardMove } from "./utils/dataObjectUtils";
+import { Move, Participant, StandardMove } from "./utils/dataObjectUtils";
 import { MOVES } from "./utils/dataUtils";
 
 export class View {
@@ -52,6 +52,17 @@ export class View {
   ): void {
     this.movesEl.textContent = `You played ${playerMove}. Computer played ${computerMove}.`;
     this.resultEl.textContent = result.toUpperCase();
+    this.movesEl.style.display = "block";
+    this.resultEl.style.display = "block";
+  }
+
+  showMatchOutcome(
+    playerMove: Move | null,
+    computerMove: Move | null,
+    winner: Participant
+  ): void {
+    this.movesEl.textContent = `You played ${playerMove}. Computer played ${computerMove}.`;
+    this.resultEl.textContent = `${winner.toUpperCase()} WON THE MATCH!`;
     this.movesEl.style.display = "block";
     this.resultEl.style.display = "block";
   }


### PR DESCRIPTION
This PR fundamentally changes the game from single rounds to full matches, introducing health mechanics, match victory conditions, and seamless progression between rounds and matches.

**Key Updates**:
- Health System: Players and computers now have health pools that deplete when they lose a round.
- Match Endings: The game now determines a match winner when one participant's health reaches zero.
- Match Progression: The game tracks and increments match numbers, smoothly transitioning to new matches after a victory.
- Controller Logic: endRound now intelligently handles round outcomes vs. match outcomes, updating the view and model accordingly. handleNextRound ensures proper match data initialization.
- View Updates: A new showMatchOutcome method visually announces the match winner to the player.
- Robust setDefaultMatchData: Fixed an important bug where DEFAULT_MATCH was passed by reference; it's now properly cloned for each new match, ensuring clean state.
- Minor Improvements: Refined Tara count logic and renamed tie for clarity.

This work sets the stage for a more engaging and complete game experience.