### PR TITLE
CLEANUP-9: Remove common move restriction

### DIFF
--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -582,29 +582,7 @@ describe("Model", () => {
       expect(model.getComputerMostCommonMove()).toBeNull();
     });
 
-    test("returns false when round is 1", () => {
-      jest.spyOn(model, "getRoundNumber").mockReturnValue(1);
-      jest.spyOn(model, "getPlayerMostCommonMove").mockReturnValue(MOVES.ROCK);
-      jest
-        .spyOn(model, "getComputerMostCommonMove")
-        .mockReturnValue(MOVES.SCISSORS);
-
-      expect(model.showMostCommonMove()).toBe(false);
-    });
-
     describe("showMostCommonMove", () => {
-      test("returns false when round is 1", () => {
-        jest.spyOn(model, "getRoundNumber").mockReturnValue(1);
-        jest
-          .spyOn(model, "getPlayerMostCommonMove")
-          .mockReturnValue(MOVES.ROCK);
-        jest
-          .spyOn(model, "getComputerMostCommonMove")
-          .mockReturnValue(MOVES.SCISSORS);
-
-        expect(model.showMostCommonMove()).toBe(false);
-      });
-
       test("returns false when both player and computer most common moves are missing", () => {
         jest.spyOn(model, "getRoundNumber").mockReturnValue(3);
         jest.spyOn(model, "getPlayerMostCommonMove").mockReturnValue(null);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -375,9 +375,8 @@ export class Model {
 
   showMostCommonMove(): boolean {
     return (
-      this.getRoundNumber() > 1 &&
-      (this.getPlayerMostCommonMove() !== null ||
-        this.getComputerMostCommonMove() !== null)
+      this.getPlayerMostCommonMove() !== null ||
+      this.getComputerMostCommonMove() !== null
     );
   }
 


### PR DESCRIPTION
Previously, the most common move table would only show when the current round !== 1.
But now it will!