### PR TITLE
RPST-22: Refactor game scoring to track and display "Match Wins" instead of "Round Wins."

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <!-- Scoreboard Table -->
     <table border="1">
       <caption>
-        Scoreboard (Round Wins)
+        Scoreboard (Match Wins)
       </caption>
       <thead>
         <tr>

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -49,6 +49,7 @@ describe("Controller", () => {
       incrementMatchNumber: jest.fn(),
       getMatchWinner: jest.fn(),
       getMatchNumber: jest.fn(),
+      handleMatchWin: jest.fn(),
       setDefaultMatchData: jest.fn(),
       getHealth: jest.fn(),
     };
@@ -271,7 +272,7 @@ describe("Controller", () => {
       mockModel.getPlayerMove.mockReturnValue("rock");
       mockModel.getComputerMove.mockReturnValue("scissors");
       mockModel.isMatchOver.mockReturnValue(true);
-      mockModel.getMatchWinner.mockReturnValue(PARTICIPANTS.PLAYER);
+      mockModel.handleMatchWin.mockReturnValue(PARTICIPANTS.PLAYER);
       mockModel.incrementMatchNumber.mockImplementation(() => {});
       mockModel.setMatch.mockImplementation(() => {});
       mockModel.increaseRoundNumber.mockImplementation(() => {});
@@ -300,7 +301,7 @@ describe("Controller", () => {
       // but good practice to mock it if it theoretically could be.
       mockModel.evaluateRound.mockReturnValue("Computer wins the round!");
       mockModel.isMatchOver.mockReturnValue(true); // Key for this test
-      mockModel.getMatchWinner.mockReturnValue(matchWinner); // Key for this test
+      mockModel.handleMatchWin.mockReturnValue(matchWinner); // Key for this test
       mockModel.incrementMatchNumber.mockImplementation(() => {});
       mockModel.setMatch.mockImplementation(() => {}); // Set to null after match end
 

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -71,7 +71,7 @@ export class Controller {
     this.updateHealthView();
 
     if (isMatchOver) {
-      const winner = this.model.getMatchWinner();
+      const winner = this.model.handleMatchWin();
       this.view.showMatchOutcome(playerMove, computerMove, winner);
       this.model.incrementMatchNumber();
       this.model.setMatch(null);

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -124,6 +124,24 @@ describe("Model", () => {
       expect(model.getPlayerScore()).toBe(5);
       expect(model.getComputerScore()).toBe(3);
     });
+
+    test("does not increment on player round win", () => {
+      model.setPlayerMove(MOVES.TARA);
+      model.setComputerMove(MOVES.SCISSORS);
+
+      model.evaluateRound();
+      expect(model.getPlayerScore()).toBe(0);
+      expect(model.getComputerScore()).toBe(0);
+    });
+
+    test("does not increment on computer round win", () => {
+      model.setPlayerMove(MOVES.ROCK);
+      model.setComputerMove(MOVES.PAPER);
+
+      model.evaluateRound();
+      expect(model.getPlayerScore()).toBe(0);
+      expect(model.getComputerScore()).toBe(0);
+    });
   });
 
   describe("Moves", () => {
@@ -183,8 +201,6 @@ describe("Model", () => {
       model.setComputerMove(MOVES.SCISSORS);
 
       expect(model.evaluateRound()).toBe("You win the round!");
-      expect(model.getPlayerScore()).toBe(1);
-      expect(model.getComputerScore()).toBe(0);
     });
 
     test("returns 'Computer wins the round!' if computer beats player and updates score", () => {
@@ -192,8 +208,6 @@ describe("Model", () => {
       model.setComputerMove(MOVES.SCISSORS);
 
       expect(model.evaluateRound()).toBe("Computer wins the round!");
-      expect(model.getComputerScore()).toBe(1);
-      expect(model.getPlayerScore()).toBe(0);
     });
   });
 
@@ -995,6 +1009,56 @@ describe("Model", () => {
       expect(model["state"].currentMatch?.computerHealth).toBe(50);
       model.setDefaultMatchData();
       expect(model["state"].currentMatch?.computerHealth).toBe(50);
+    });
+  });
+
+  describe("handleMatchWin", () => {
+    test("should increment the player's score and return PLAYER if player wins the match", () => {
+      // Setup the model state to make the Player the match winner
+      model.setMatch({ ...DEFAULT_MATCH });
+      model.setPlayerMove(MOVES.ROCK);
+      model.setComputerMove(MOVES.SCISSORS);
+      model.evaluateRound();
+
+      model.setPlayerMove(MOVES.TARA);
+      model.setComputerMove(MOVES.PAPER);
+      model.evaluateRound();
+
+      expect(model.isMatchOver()).toBe(true);
+      expect(model.getMatchWinner()).toBe(PARTICIPANTS.PLAYER);
+
+      const initialPlayerScore = model.getPlayerScore();
+      const initialComputerScore = model.getComputerScore();
+
+      const winner = model.handleMatchWin(); // Call the method being tested
+
+      expect(model.getPlayerScore()).toBe(initialPlayerScore + 1);
+      expect(model.getComputerScore()).toBe(initialComputerScore);
+      expect(winner).toBe(PARTICIPANTS.PLAYER);
+    });
+
+    test("should increment the computer's score and return COMPUTER if computer wins the match", () => {
+      // Setup the model state to make the Computer the match winner
+      model.setMatch({ ...DEFAULT_MATCH });
+      model.setPlayerMove(MOVES.ROCK);
+      model.setComputerMove(MOVES.TARA);
+      model.evaluateRound();
+
+      model.setPlayerMove(MOVES.PAPER);
+      model.setComputerMove(MOVES.SCISSORS);
+      model.evaluateRound();
+
+      expect(model.isMatchOver()).toBe(true);
+      expect(model.getMatchWinner()).toBe(PARTICIPANTS.COMPUTER);
+
+      const initialPlayerScore = model.getPlayerScore();
+      const initialComputerScore = model.getComputerScore();
+
+      const winner = model.handleMatchWin(); // Call the method being tested
+
+      expect(model.getPlayerScore()).toBe(initialPlayerScore);
+      expect(model.getComputerScore()).toBe(initialComputerScore + 1);
+      expect(winner).toBe(PARTICIPANTS.COMPUTER);
     });
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -83,8 +83,6 @@ export class Model {
   }
 
   private handleRoundWin(winner: Participant, winningMove: Move): void {
-    this.setScore(winner, this.getScore(winner) + 1);
-
     if (this.isStandardMove(winningMove)) {
       const currentTara = this.getTaraCount(winner);
       if (currentTara < 3) {
@@ -469,6 +467,14 @@ export class Model {
   }
 
   // ===== Match Methods =====
+
+  handleMatchWin(): Participant {
+    const winner = this.getMatchWinner();
+
+    this.setScore(winner, this.getScore(winner) + 1);
+
+    return winner;
+  }
 
   setMatch(match: Match | null): void {
     this.state.currentMatch = match;


### PR DESCRIPTION
**Model**:
- Introduced a new `handleMatchWin()` method responsible for incrementing a player's score only when they win an entire match.
- Removed score incrementation logic from `handleRoundWin()` to ensure rounds no longer directly affect the main scoreboard.

**Controller**:
- Updated the `endRound()` method to utilize the new `handleMatchWin()` method when a match concludes.

**Public/UI**:
- Modified the scoreboard caption in `index.html` to clearly state "Scoreboard (Match Wins)."