### PR TITLE
RPST-24: Display 'Tara Count Table' only during rounds

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,25 +27,6 @@
       </tbody>
     </table>
 
-    <!-- Tara Count Table -->
-    <table border="1">
-      <caption>
-        Tara Count
-      </caption>
-      <thead>
-        <tr>
-          <th>Player</th>
-          <th>Computer</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td id="player-tara">0</td>
-          <td id="computer-tara">0</td>
-        </tr>
-      </tbody>
-    </table>
-
     <!-- Health Table -->
     <table border="1" style="display: none" id="health-table">
       <caption>
@@ -61,6 +42,25 @@
         <tr>
           <td id="player-health">0</td>
           <td id="computer-health">0</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Tara Count Table -->
+    <table border="1" style="display: none" id="tara-table">
+      <caption>
+        Tara Count
+      </caption>
+      <thead>
+        <tr>
+          <th>Player</th>
+          <th>Computer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td id="player-tara">0</td>
+          <td id="computer-tara">0</td>
         </tr>
       </tbody>
     </table>

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -62,6 +62,7 @@ describe("Controller", () => {
       showRoundOutcome: jest.fn(),
       toggleMoveButtons: jest.fn(),
       togglePlayAgain: jest.fn(),
+      updatePlayAgainButton: jest.fn(),
       toggleStartButton: jest.fn(),
       resetForNextRound: jest.fn(),
       updateTaraCounts: jest.fn(),
@@ -76,6 +77,7 @@ describe("Controller", () => {
       toggleTaraButton: jest.fn(),
       updateHealth: jest.fn(),
       toggleHealthTable: jest.fn(),
+      toggleTaraTable: jest.fn(),
     };
 
     controller = new Controller(mockModel, mockView);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -56,6 +56,7 @@ export class Controller {
     this.view.updateMatch(matchNumber);
     this.view.toggleStartButton(false);
     this.view.toggleResetGameState(false);
+    this.view.toggleTaraTable(true);
     this.view.toggleHealthTable(true);
     this.view.toggleMostCommonMoveTable(showMostCommonMove);
     this.view.toggleMoveButtons(true);
@@ -85,6 +86,7 @@ export class Controller {
     this.updateMostCommonMoveView();
     this.updateTaraButtonView();
     this.view.updatePlayAgainButton(isMatchOver);
+    this.view.toggleTaraTable(false);
     this.view.toggleMostCommonMoveTable(false);
     this.view.toggleMoveButtons(false);
     this.view.togglePlayAgain(true);
@@ -138,6 +140,7 @@ export class Controller {
     this.updateMostCommonMoveView();
     this.updateTaraButtonView();
     this.view.updateStartButton(isMatchActive);
+    this.view.toggleTaraTable(false);
     this.view.toggleHealthTable(false);
     this.view.toggleMostCommonMoveTable(false);
     this.view.toggleMoveButtons(false);

--- a/src/view.ts
+++ b/src/view.ts
@@ -93,6 +93,7 @@ export class View {
   }
 
   resetForNextRound(): void {
+    this.toggleTaraTable(true);
     this.toggleHealthTable(true);
     this.toggleMostCommonMoveTable(true);
     this.toggleMoveButtons(true);
@@ -141,6 +142,11 @@ export class View {
     }
 
     this.taraBtn.textContent = `Tara (x${taraCount})`;
+  }
+
+  toggleTaraTable(show: boolean): void {
+    const table = document.getElementById("tara-table");
+    if (table) table.style.display = show ? "table" : "none";
   }
 
   // ===== History Methods =====


### PR DESCRIPTION
The 'Tara Count Table' is not displayed on the home screen.

The 'Tara Count Table' is not displayed when round or match outcomes are shown.

The 'Tara Count Table' is displayed during an active round.