### PR TITLE
RPST-31 ESLint & Jest mocks refactor for TypeScript compliance

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,17 @@
 import { defineConfig } from "eslint/config";
 import globals from "globals";
-import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts}"] },
   {
-    files: ["**/*.{js,mjs,cjs,ts}"],
+    files: ["**/*.ts"],
     languageOptions: { globals: globals.browser },
+    extends: [...tseslint.configs.recommended],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
   },
-  {
-    files: ["**/*.{js,mjs,cjs,ts}"],
-    plugins: { js },
-    extends: ["js/recommended"],
-  },
-  tseslint.configs.recommended,
 ]);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "npx parcel build public/index.html --dist-dir dist --public-url ./",
     "start": "npx parcel serve public/index.html --open",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint 'src/**/*.ts'",
+    "lint:fix": "eslint 'src/**/*.ts' --fix"
   },
   "keywords": [],
   "author": "Tara Timmerman",

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,13 +1,13 @@
-import { Model } from "../model/model";
-import { View } from "../view/view";
+import { IModel } from "../model/IModel";
+import { IView } from "../view/IView";
 import { Move } from "../utils/dataObjectUtils";
 import { MOVES, PARTICIPANTS } from "../utils/dataUtils";
 
 export class Controller {
-  private model: Model;
-  private view: View;
+  private model: IModel;
+  private view: IView;
 
-  constructor(model: Model, view: View) {
+  constructor(model: IModel, view: IView) {
     this.model = model;
     this.view = view;
   }
@@ -45,13 +45,13 @@ export class Controller {
   private updateTaraButtonView(): void {
     const isEnabled = this.model.taraIsEnabled();
     const taraCount = this.model.getPlayerTaraCount();
+
     this.view.updateTaraButton(isEnabled, taraCount);
   }
 
   private startGame(): void {
     const roundNumber = this.model.getRoundNumber();
     const matchNumber = this.model.getMatchNumber();
-    const showMostCommonMove = this.model.showMostCommonMove();
 
     this.model.setDefaultMatchData();
     this.view.updateRound(roundNumber);

--- a/src/model/IModel.ts
+++ b/src/model/IModel.ts
@@ -1,0 +1,50 @@
+import { Match, Move, Participant } from "../utils/dataObjectUtils";
+
+export interface IModel {
+  // Score
+  getPlayerScore(): number;
+  getComputerScore(): number;
+  setPlayerScore(score: number): void;
+  setComputerScore(score: number): void;
+
+  // Moves
+  getPlayerMove(): Move;
+  getComputerMove(): Move;
+  registerPlayerMove(move: Move): void;
+  chooseComputerMove(): void;
+  evaluateRound(): string;
+  resetMoves(): void;
+
+  // Tara
+  getPlayerTaraCount(): number;
+  getComputerTaraCount(): number;
+  taraIsEnabled(): boolean;
+  isTaraButtonVisible(): boolean;
+  resetTaras(): void;
+
+  // Most common moves
+  getPlayerMostCommonMove(): Move | null;
+  getComputerMostCommonMove(): Move | null;
+  resetBothMoveCounts(): void;
+  resetMostCommonMoves(): void;
+  showMostCommonMove(): boolean;
+
+  // Match & round
+  isMatchActive(): boolean;
+  isMatchOver(): boolean;
+  handleMatchWin(): Participant;
+  incrementMatchNumber(): void;
+  increaseRoundNumber(): void;
+  getRoundNumber(): number;
+  getMatchNumber(): number;
+  setMatch(match: Match | null): void;
+  setDefaultMatchData(): void;
+  resetHistories(): void;
+  resetMatchData(): void;
+
+  // Health
+  getHealth(participant: Participant): number;
+
+  // Optional setters for testing or future expansion
+  resetScores(): void;
+}

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -1069,32 +1069,32 @@ describe("Model Constructor - Initialization and Migration", () => {
 
   beforeEach(() => {
     constructorMockGameStorage = {
-      getScore: jest.fn((participant: Participant) => 0),
-      setScore: jest.fn((participant: Participant, score: number) => {}),
-      removeScore: jest.fn((participant: Participant) => {}),
+      getScore: jest.fn((_participant: Participant) => 0),
+      setScore: jest.fn((_participant: Participant, _score: number) => {}),
+      removeScore: jest.fn((_participant: Participant) => {}),
 
-      getTaraCount: jest.fn((participant: Participant) => 0),
-      setTaraCount: jest.fn((participant: Participant, count: number) => {}),
-      removeTaraCount: jest.fn((participant: Participant) => {}),
+      getTaraCount: jest.fn((_participant: Participant) => 0),
+      setTaraCount: jest.fn((_participant: Participant, _count: number) => {}),
+      removeTaraCount: jest.fn((_participant: Participant) => {}),
 
-      getMostCommonMove: jest.fn((participant: Participant) => null),
+      getMostCommonMove: jest.fn((_participant: Participant) => null),
       setMostCommonMove: jest.fn(
-        (participant: Participant, move: StandardMove | null) => {}
+        (_participant: Participant, _move: StandardMove | null) => {}
       ),
-      removeMostCommonMove: jest.fn((participant: Participant) => {}),
+      removeMostCommonMove: jest.fn((_participant: Participant) => {}),
 
-      getMoveCounts: jest.fn((participant: Participant) => ({
+      getMoveCounts: jest.fn((_participant: Participant) => ({
         rock: 0,
         paper: 0,
         scissors: 0,
       })),
       setMoveCounts: jest.fn(
-        (participant: Participant, moveCounts: MoveCount) => {}
+        (_participant: Participant, _moveCounts: MoveCount) => {}
       ),
-      removeMoveCounts: jest.fn((participant: Participant) => {}),
+      removeMoveCounts: jest.fn((_participant: Participant) => {}),
 
       getRoundNumber: jest.fn(() => 1),
-      removeHistory: jest.fn((participant: Participant) => {}),
+      removeHistory: jest.fn((_participant: Participant) => {}),
 
       getMatch: jest.fn(() => null),
       setMatch: jest.fn(),

--- a/src/view/IView.ts
+++ b/src/view/IView.ts
@@ -1,0 +1,32 @@
+import { Move, Participant } from "../utils/dataObjectUtils";
+
+export interface IView {
+  updateMessage(msg: string): void;
+  updateScores(playerScore: number, computerScore: number): void;
+  updateRound(roundNumber: number): void;
+  updateMatch(matchNumber: number): void;
+  showRoundOutcome(playerMove: Move, computerMove: Move, result: string): void;
+  showMatchOutcome(
+    playerMove: Move,
+    computerMove: Move,
+    winner: Participant
+  ): void;
+  toggleMoveButtons(enabled: boolean): void;
+  togglePlayAgain(enabled: boolean): void;
+  updateTaraCounts(playerTara: number, computerTara: number): void;
+  updateTaraButton(isEnabled: boolean, taraCount: number): void;
+  updateMostCommonMoves(
+    playerMove: Move | null,
+    computerMove: Move | null
+  ): void;
+  updatePlayAgainButton(isMatchOver: boolean): void;
+  resetForNextRound(): void;
+  updateScoreView(): void;
+  updateTaraView(): void;
+  updateTaraButtonView(): void;
+  toggleControls(enabled: boolean): void;
+  toggleGameStats(enabled: boolean): void;
+  updateHealth(playerHealth: number, computerHealth: number): void;
+  updateHealthBar(participant: Participant, health: number): void;
+  updateStartButton(isMatchActive: boolean): void;
+}


### PR DESCRIPTION
- Target TypeScript files in ESLint and extend recommended rules.
- Configure `@typescript-eslint/no-unused-vars` to allow `_` prefix for ignored variables.
- Refactor Jest mocks to use `jest.Mocked<IModel>` / `jest.Mocked<IView>` instead of `any`.
- Enable spying on private controller methods via standalone interface + `unknown` cast.
- Add `lint` and `lint:fix` scripts to package.json.
- Eliminates lint errors, improves test type safety, and aligns Controller with MVC best practices.