### PR TITLE
RPST-34 Decouple Event Handling from Controller

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -67,6 +67,10 @@ describe("Controller", () => {
 
     mockView = {
       activateSpinner: jest.fn(),
+      bindStartGame: jest.fn(),
+      bindPlayAgain: jest.fn(),
+      bindResetGame: jest.fn(),
+      bindPlayerMove: jest.fn(),
       updateMessage: jest.fn(),
       updateScores: jest.fn(),
       updateRound: jest.fn(),
@@ -157,7 +161,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.ROCK)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.ROCK);
     expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.ROCK);
   });
 
@@ -166,7 +171,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.PAPER)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.PAPER);
     expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.PAPER);
   });
 
@@ -175,7 +181,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.SCISSORS)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.SCISSORS);
     expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.SCISSORS);
   });
 
@@ -184,7 +191,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.TARA)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.TARA);
     expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.TARA);
   });
 
@@ -193,7 +201,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.ROCK)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.ROCK);
     expect(mockModel.chooseComputerMove).toHaveBeenCalled();
   });
 
@@ -202,7 +211,8 @@ describe("Controller", () => {
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await initializationPromise;
 
-    document.getElementById(MOVES.ROCK)!.click();
+    const playerMoveHandler = mockView.bindPlayerMove.mock.calls[0][0];
+    playerMoveHandler(MOVES.ROCK);
 
     jest.advanceTimersByTime(DEFAULT_DELAY);
     await Promise.resolve();

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -160,22 +160,9 @@ export class Controller {
     this.view.togglePlayAgain(false);
     this.view.toggleControls(true);
 
-    document
-      .getElementById("start")
-      ?.addEventListener("click", () => this.startGame());
-
-    document
-      .getElementById("play-again")
-      ?.addEventListener("click", () => this.handleNextRound());
-
-    Object.values(MOVES).forEach((move) => {
-      document
-        .getElementById(move)
-        ?.addEventListener("click", () => this.handlePlayerMove(move));
-    });
-
-    document
-      .getElementById("reset-game-state")
-      ?.addEventListener("click", () => this.resetGameState());
+    this.view.bindStartGame(() => this.startGame());
+    this.view.bindPlayAgain(() => this.handleNextRound());
+    this.view.bindResetGame(() => this.resetGameState());
+    this.view.bindPlayerMove((move) => this.handlePlayerMove(move));
   }
 }

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -14,6 +14,8 @@ export type MoveData = {
 
 export type MoveCount = Record<StandardMove, number>;
 
+export type VoidHandler = () => void;
+
 export interface Match {
   matchRoundNumber: number;
   playerHealth: number;

--- a/src/view/IView.ts
+++ b/src/view/IView.ts
@@ -1,7 +1,11 @@
-import { Move, Participant } from "../utils/dataObjectUtils";
+import { Move, Participant, VoidHandler } from "../utils/dataObjectUtils";
 
 export interface IView {
   activateSpinner(shouldActivate: boolean): void;
+  bindStartGame(handler: VoidHandler): void;
+  bindPlayAgain(handler: VoidHandler): void;
+  bindResetGame(handler: VoidHandler): void;
+  bindPlayerMove(handler: (move: Move) => void): void;
   updateMessage(msg: string): void;
   updateScores(playerScore: number, computerScore: number): void;
   updateRound(roundNumber: number): void;

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -3,7 +3,9 @@ import {
   Move,
   Participant,
   StandardMove,
+  VoidHandler,
 } from "../utils/dataObjectUtils";
+import { MOVES } from "../utils/dataUtils";
 
 export class View {
   private messageEl = this.getEl<HTMLElement>("message");
@@ -33,6 +35,7 @@ export class View {
   private startBtn = this.getEl<HTMLButtonElement>("start");
   private playAgainBtn = this.getEl<HTMLButtonElement>("play-again");
   private gameStatsEl = this.getEl<HTMLButtonElement>("game-stats");
+  private resetBtn = this.getEl<HTMLButtonElement>("reset-game-state");
 
   // ===== Helper Methods =====
   private getEl<T extends HTMLElement>(id: string): T | null {
@@ -41,6 +44,26 @@ export class View {
 
   private toggle(el: HTMLElement | null, show: boolean): void {
     if (el) el.classList.toggle("hidden", !show);
+  }
+
+  // ===== Binding Methods =====
+
+  bindStartGame(handler: VoidHandler) {
+    this.startBtn?.addEventListener("click", handler);
+  }
+
+  bindPlayAgain(handler: VoidHandler) {
+    this.playAgainBtn?.addEventListener("click", handler);
+  }
+
+  bindResetGame(handler: VoidHandler) {
+    this.resetBtn?.addEventListener("click", handler);
+  }
+
+  bindPlayerMove(handler: (move: Move) => void) {
+    Object.values(MOVES).forEach((move) => {
+      this.getEl(move)?.addEventListener("click", () => handler(move));
+    });
   }
 
   // ===== General Methods =====


### PR DESCRIPTION
**Summary**
Refactors event-handling logic to improve separation of concerns by moving DOM listener binding into the View layer. The Controller now interacts only with the View’s public API and no longer queries the DOM directly.

**What’s Changed**
- Added bindStartGame, bindPlayAgain, bindResetGame, and bindPlayerMove methods to View.ts.
- Updated Controller.initialize() to use these methods instead of document.getElementById.
- Removed all direct DOM references from the Controller.
- Updated unit tests to verify Controller ↔ View interactions using mock views instead of simulating real DOM events.

**Why**
- Reduces coupling between Controller and DOM structure.
- Improves MVC adherence and encapsulation.
- Simplifies Controller logic and improves testability.
- Makes future UI changes easier and less error-prone.
- Makes unit tests faster and more reliable by mocking View behavior.

**Acceptance Criteria**
-  All event listeners are bound via the View layer.
-  Controller uses only public bind* methods.
-  Controller no longer depends on element IDs.
-  Unit tests validate handler wiring instead of DOM clicks.
-  Existing behavior remains unchanged.