### PR TITLE
RPST-77 chore: update browserslist and caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
         "@typescript-eslint/parser": "^8.27.0",
-        "baseline-browser-mapping": "^2.9.11",
         "eslint": "^9.23.0",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
@@ -13320,13 +13319,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/boolbase": {
@@ -13458,9 +13460,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001741",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
-      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
-    "baseline-browser-mapping": "^2.9.11",
     "eslint": "^9.23.0",
     "globals": "^16.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
Updates project's browser compatibility data. Periodically refreshing the browserslist database ensures build artifacts are optimized for the most recent browser market share data.

**Changes**
- **Dependency Update**: Bumped `caniuse-lite` to the latest version.
- **Refactor**: Removed `baseline-browser-mapping` from `package.json`. It is no longer required as a top-level dependency but remains correctly resolved in `package-lock.json`.
- **Lockfile Maintenance:** Synchronized `package-lock.json` with the new dependency tree.

**Why this is needed**
Keeping `caniuse-lite` up to date prevents "outdated database" warnings during build time and ensures that CSS/JS polyfills are only applied where strictly necessary for modern browsers.

**Testing**
- [x] npm install completes without errors.
- [x] Build process succeeds.
- [x] Core functionality remains intact.
- [x] All unit tests passed.