### PR TITLE
RPST-78: chore: update tsconfig moduleResolution to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,17 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
-    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "types": ["jest"]
+    "types": ["jest"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "include": ["src", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Updates the TypeScript configuration to use the modern `bundler` module resolution strategy.

**Why?**
The previous setting, `"node"`, is now deprecated in favor of `node10`. For projects using modern bundlers like Parcel, the recommended strategy is now `bundler`. This setting:
- Silences the TypeScript 7.0 deprecation warning.
- Better supports modern package `exports`.
- Maintains support for extensionless imports, which Parcel expects.

**Changes**
Modified `tsconfig.json`:
- Changed `moduleResolution` from `node` to `bundler`.
- Added allowImportingTsExtensions: true (optional but recommended for this mode).
- Added noEmit: true (since Parcel, not tsc, handles our file emission).

**Verification Results**
- [x] npm run build completed successfully.
- [x] npm test passed.
- [x] Linting passed.