### PR TITLE
RPST-82: refactor: extend base View class in StatsView and clean up initialization lifecycle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,40 +11,7 @@
       <section id="main-menu"></section>
 
       <div id="game-container" class="hidden" inert>
-        <section id="game-stats">
-          <aside id="player-stats" class="stats">
-            <div class="score-row"><span id="player-score">00</span> WINS</div>
-            <div class="bar-wrapper">
-              <div class="bar" id="player-health"></div>
-              <span class="bar-text">PLAYER</span>
-            </div>
-            <p>Tara x<span id="player-tara">0</span></p>
-            <p>
-              <small>Common: <span id="player-most-common-move">–</span></small>
-            </p>
-          </aside>
-
-          <section id="game-progress-container">
-            <h2 id="match">Match 1</h2>
-            <h3 id="round">Round 1</h3>
-          </section>
-
-          <aside id="computer-stats" class="stats">
-            <div class="score-row">
-              WINS <span id="computer-score">00</span>
-            </div>
-            <div class="bar-wrapper">
-              <div class="bar" id="computer-health"></div>
-              <span class="bar-text">COMPUTER</span>
-            </div>
-            <p>Tara x<span id="computer-tara">0</span></p>
-            <p>
-              <small
-                >Common: <span id="computer-most-common-move">–</span></small
-              >
-            </p>
-          </aside>
-        </section>
+        <section id="game-stats"></section>
 
         <div id="arena">
           <div id="announcement-container" aria-live="polite"></div>

--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -91,11 +91,9 @@ describe("Controller", () => {
         highlightWinner: jest.fn().mockResolvedValue(undefined),
       } as any,
       statsView: {
-        updateScores: jest.fn(),
-        updateTaraCounts: jest.fn(),
-        updateMostCommonMoves: jest.fn(),
-        updateHealthBar: jest.fn(),
-        updateProgress: jest.fn(),
+        hasData: false,
+        render: jest.fn(),
+        update: jest.fn(),
         toggleGameStatsVisibility: jest.fn(),
       } as any,
       statusView: { render: jest.fn(), setMessage: jest.fn() } as any,
@@ -125,7 +123,10 @@ describe("Controller", () => {
       controller.endRound("player wins round");
 
       expect(mockModel.handleMatchWin).toHaveBeenCalled();
-      expect(mockViews.statsView.updateScores).toHaveBeenCalled();
+
+      // Since mockViews.statsView.hasData is false, it should call render instead of update
+      expect(mockViews.statsView.render).toHaveBeenCalled();
+
       expect(mockViews.controlsView.render).toHaveBeenCalledWith(
         expect.objectContaining({
           isMatchOver: true,
@@ -166,7 +167,9 @@ describe("Controller", () => {
 
       expect(mockModel.resetScores).toHaveBeenCalled();
       expect(mockModel.resetMatchData).toHaveBeenCalled();
-      expect(mockViews.statsView.updateScores).toHaveBeenCalled();
+
+      expect(mockViews.statsView.render).toHaveBeenCalled();
+
       expect(mockViews.moveRevealView.toggleVisibility).toHaveBeenCalledWith(
         false,
       );

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -250,7 +250,6 @@ export class Controller {
 
   async initialize(): Promise<void> {
     const isMatchActive = this.model.isMatchActive();
-    console.log(this.model.getMatchNumber());
     this.menuView.render({ isMatchActive });
 
     this.announcementView.render({ message: "" });
@@ -258,7 +257,6 @@ export class Controller {
 
     this.updateControlsView();
     this.updateStatsView();
-    console.log(this.model.getMatchNumber());
 
     this.statsView.toggleGameStatsVisibility(false);
     this.controlsView.toggleVisibility(false);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -4,7 +4,7 @@ import { IControlsView } from "../views/controls/IControlsView";
 import { IGameView } from "../views/game/IGameView";
 import { IMenuView } from "../views/menu/IMenuView";
 import { IMoveRevealView } from "../views/moveReveal/IMoveRevealView";
-import { IStatsView } from "../views/stats/IStatsView";
+import { IStatsView, StatsViewData } from "../views/stats/IStatsView";
 import { IStatusView } from "../views/status/IStatusView";
 import { Move } from "../utils/dataObjectUtils";
 import {
@@ -54,41 +54,26 @@ export class Controller {
     });
   }
 
-  private updateProgressView(options: { isVisible: boolean }): void {
-    this.statsView.updateProgress(
-      this.model.getMatchNumber(),
-      this.model.getRoundNumber(),
-      options.isVisible,
-    );
-  }
+  private updateStatsView(options: { isProgressVisible?: boolean } = {}): void {
+    const data: StatsViewData = {
+      playerHealth: this.model.getHealth(PARTICIPANTS.PLAYER) ?? 100,
+      computerHealth: this.model.getHealth(PARTICIPANTS.COMPUTER) ?? 100,
+      playerScore: this.model.getPlayerScore() || 0,
+      computerScore: this.model.getComputerScore() || 0,
+      playerTara: this.model.getPlayerTaraCount() || 0,
+      computerTara: this.model.getComputerTaraCount() || 0,
+      playerMostCommonMove: this.model.getPlayerMostCommonMove(),
+      computerMostCommonMove: this.model.getComputerMostCommonMove(),
+      matchNumber: this.model.getMatchNumber() || 1,
+      roundNumber: this.model.getRoundNumber() || 1,
+      isProgressVisible: options.isProgressVisible ?? true,
+    };
 
-  private updateScoreView(): void {
-    this.statsView.updateScores(
-      this.model.getPlayerScore(),
-      this.model.getComputerScore(),
-    );
-  }
-
-  private updateTaraView(): void {
-    this.statsView.updateTaraCounts(
-      this.model.getPlayerTaraCount(),
-      this.model.getComputerTaraCount(),
-    );
-  }
-
-  private updateMostCommonMoveView(): void {
-    this.statsView.updateMostCommonMoves(
-      this.model.getPlayerMostCommonMove(),
-      this.model.getComputerMostCommonMove(),
-    );
-  }
-
-  private updateHealthView(): void {
-    const playerHealth = this.model.getHealth(PARTICIPANTS.PLAYER);
-    const computerHealth = this.model.getHealth(PARTICIPANTS.COMPUTER);
-
-    this.statsView.updateHealthBar(PARTICIPANTS.PLAYER, playerHealth);
-    this.statsView.updateHealthBar(PARTICIPANTS.COMPUTER, computerHealth);
+    if (!this.statsView.hasData) {
+      this.statsView.render(data);
+    } else {
+      this.statsView.update(data);
+    }
   }
 
   private async startGame(): Promise<void> {
@@ -109,7 +94,7 @@ export class Controller {
     const matchActuallyEnded = this.model.isMatchOver();
     const isDoubleKO = this.model.isDoubleKO();
 
-    this.updateHealthView();
+    this.updateStatsView();
     let resultMessage = roundResult.toUpperCase();
 
     this.statusView.setMessage(
@@ -128,9 +113,7 @@ export class Controller {
 
       this.model.incrementMatchNumber();
 
-      this.updateScoreView();
-      this.updateMostCommonMoveView();
-      this.updateTaraView();
+      this.updateStatsView();
       this.updateControlsView();
 
       this.model.setMatch(null);
@@ -139,9 +122,7 @@ export class Controller {
 
     // --- ROUND CONTINUES ---
     this.announcementView.setMessage(resultMessage);
-    this.updateScoreView();
-    this.updateTaraView();
-    this.updateMostCommonMoveView();
+    this.updateStatsView();
 
     this.model.increaseRoundNumber();
 
@@ -157,7 +138,7 @@ export class Controller {
     this.moveRevealView.toggleVisibility(false);
 
     this.updateControlsView();
-    this.updateProgressView({ isVisible: true });
+    this.updateStatsView({ isProgressVisible: true });
 
     this.statusView.setMessage("Prepare your next move...");
 
@@ -167,32 +148,23 @@ export class Controller {
 
   async resetGameState(): Promise<void> {
     this.model.resetScores();
-    this.model.resetMoves();
     this.model.resetTaras();
     this.model.resetHistories();
     this.model.resetBothMoveCounts();
     this.model.resetMostCommonMoves();
     this.model.resetMatchData();
 
-    const isMatchActive = this.model.isMatchActive();
-
-    this.updateScoreView();
-    this.updateTaraView();
-    this.updateHealthView();
-    this.updateMostCommonMoveView();
-    this.updateControlsView();
+    this.menuView.updateMenu({ isMatchActive: false });
+    this.updateStatsView({ isProgressVisible: false });
 
     this.moveRevealView.toggleVisibility(false);
     this.controlsView.toggleVisibility(false);
-    this.menuView.updateMenu({ isMatchActive });
-    this.announcementView.setMessage("");
   }
 
   private resetArenaVisuals(): void {
     this.moveRevealView.clear();
     this.announcementView.setMessage("");
-    this.updateProgressView({ isVisible: true });
-    this.updateHealthView();
+    this.updateStatsView({ isProgressVisible: true });
   }
 
   async handlePlayerMove(move: Move): Promise<void> {
@@ -229,7 +201,7 @@ export class Controller {
         const playerWins = this.model.doesMoveBeat(pMove, cMove);
         await this.executeOutcomeDrama(playerWins);
       } else {
-        this.updateHealthView();
+        this.updateStatsView();
         await this.moveRevealView.triggerImpact("both");
         await this.moveRevealView.triggerDefeat("both");
       }
@@ -254,7 +226,7 @@ export class Controller {
 
     this.statusView.setMessage(`${winner.toUpperCase()} LANDS A BLOW!`);
     const impactPromise = this.moveRevealView.triggerImpact(loser);
-    this.updateHealthView();
+    this.updateStatsView();
     await impactPromise;
 
     await Promise.all([
@@ -268,7 +240,7 @@ export class Controller {
 
     const impactPromise = this.moveRevealView.triggerImpact("both");
 
-    this.updateHealthView();
+    this.updateStatsView();
     await impactPromise;
 
     await this.moveRevealView.triggerDefeat("both");
@@ -279,19 +251,11 @@ export class Controller {
 
     this.menuView.render({ isMatchActive });
 
-    this.statsView.updateProgress(
-      this.model.getMatchNumber(),
-      this.model.getRoundNumber(),
-      false,
-    );
-
     this.announcementView.render({ message: "" });
     this.statusView.render({ message: "" });
 
     this.updateControlsView();
-    this.updateScoreView();
-    this.updateTaraView();
-    this.updateMostCommonMoveView();
+    this.updateStatsView({ isProgressVisible: false });
 
     this.menuView.updateMenu({ isMatchActive });
     this.statsView.toggleGameStatsVisibility(false);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -54,7 +54,7 @@ export class Controller {
     });
   }
 
-  private updateStatsView(options: { isProgressVisible?: boolean } = {}): void {
+  private updateStatsView(): void {
     const data: StatsViewData = {
       playerHealth: this.model.getHealth(PARTICIPANTS.PLAYER) ?? 100,
       computerHealth: this.model.getHealth(PARTICIPANTS.COMPUTER) ?? 100,
@@ -64,9 +64,8 @@ export class Controller {
       computerTara: this.model.getComputerTaraCount() || 0,
       playerMostCommonMove: this.model.getPlayerMostCommonMove(),
       computerMostCommonMove: this.model.getComputerMostCommonMove(),
-      matchNumber: this.model.getMatchNumber() || 1,
-      roundNumber: this.model.getRoundNumber() || 1,
-      isProgressVisible: options.isProgressVisible ?? true,
+      matchNumber: this.model.getMatchNumber(),
+      roundNumber: this.model.getRoundNumber(),
     };
 
     if (!this.statsView.hasData) {
@@ -78,6 +77,7 @@ export class Controller {
 
   private async startGame(): Promise<void> {
     this.model.setDefaultMatchData();
+    this.updateStatsView();
 
     this.resetArenaVisuals();
     this.statusView.setMessage("Get ready...");
@@ -111,11 +111,10 @@ export class Controller {
 
       this.announcementView.setMessage(resultMessage);
 
-      this.model.incrementMatchNumber();
-
       this.updateStatsView();
       this.updateControlsView();
 
+      this.model.incrementMatchNumber();
       this.model.setMatch(null);
       return;
     }
@@ -138,7 +137,7 @@ export class Controller {
     this.moveRevealView.toggleVisibility(false);
 
     this.updateControlsView();
-    this.updateStatsView({ isProgressVisible: true });
+    this.updateStatsView();
 
     this.statusView.setMessage("Prepare your next move...");
 
@@ -155,7 +154,10 @@ export class Controller {
     this.model.resetMatchData();
 
     this.menuView.updateMenu({ isMatchActive: false });
-    this.updateStatsView({ isProgressVisible: false });
+    this.menuView.bindStartMatch(() => this.startGame());
+    this.menuView.bindResetGame(() => this.resetGameState());
+
+    this.updateStatsView();
 
     this.moveRevealView.toggleVisibility(false);
     this.controlsView.toggleVisibility(false);
@@ -164,7 +166,7 @@ export class Controller {
   private resetArenaVisuals(): void {
     this.moveRevealView.clear();
     this.announcementView.setMessage("");
-    this.updateStatsView({ isProgressVisible: true });
+    this.updateStatsView();
   }
 
   async handlePlayerMove(move: Move): Promise<void> {
@@ -248,16 +250,16 @@ export class Controller {
 
   async initialize(): Promise<void> {
     const isMatchActive = this.model.isMatchActive();
-
+    console.log(this.model.getMatchNumber());
     this.menuView.render({ isMatchActive });
 
     this.announcementView.render({ message: "" });
     this.statusView.render({ message: "" });
 
     this.updateControlsView();
-    this.updateStatsView({ isProgressVisible: false });
+    this.updateStatsView();
+    console.log(this.model.getMatchNumber());
 
-    this.menuView.updateMenu({ isMatchActive });
     this.statsView.toggleGameStatsVisibility(false);
     this.controlsView.toggleVisibility(false);
     this.menuView.toggleMenuVisibility(true);

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -1073,85 +1073,39 @@ describe("Model", () => {
     });
   });
 
-  describe("Model Constructor - Initialization and Migration", () => {
+  describe("Model Constructor - State Initialization", () => {
     let constructorMockGameStorage: jest.Mocked<IGameStorage>;
     let constructorModel: Model;
 
     beforeEach(() => {
       constructorMockGameStorage = {
-        getScore: jest.fn((_participant: Participant) => 0),
-        setScore: jest.fn((_participant: Participant, _score: number) => {}),
-        removeScore: jest.fn((_participant: Participant) => {}),
-
-        getTaraCount: jest.fn((_participant: Participant) => 0),
-        setTaraCount: jest.fn(
-          (_participant: Participant, _count: number) => {},
-        ),
-        removeTaraCount: jest.fn((_participant: Participant) => {}),
-
-        getMostCommonMove: jest.fn((_participant: Participant) => null),
-        setMostCommonMove: jest.fn(
-          (_participant: Participant, _move: StandardMove | null) => {},
-        ),
-        removeMostCommonMove: jest.fn((_participant: Participant) => {}),
-
-        getMoveCounts: jest.fn((_participant: Participant) => ({
-          rock: 0,
-          paper: 0,
-          scissors: 0,
-        })),
-        setMoveCounts: jest.fn(
-          (_participant: Participant, _moveCounts: MoveCount) => {},
-        ),
-        removeMoveCounts: jest.fn((_participant: Participant) => {}),
-
-        getRoundNumber: jest.fn(() => 1),
-        removeHistory: jest.fn((_participant: Participant) => {}),
-
-        getMatch: jest.fn(() => null),
-        setMatch: jest.fn(),
-        getGlobalMatchNumber: jest.fn(() => 1),
-        setGlobalMatchNumber: jest.fn(),
-        removeGlobalMatchNumber: jest.fn(),
-        getOldGlobalRoundNumber: jest.fn(() => null),
-        removeOldGlobalRoundNumber: jest.fn(),
-      } as jest.Mocked<IGameStorage>;
+        getScore: jest.fn(() => 0),
+        getTaraCount: jest.fn(() => 0),
+        getMostCommonMove: jest.fn(() => null),
+        getMoveCounts: jest.fn(() => ({ rock: 0, paper: 0, scissors: 0 })),
+        getMatch: jest.fn(),
+        getGlobalMatchNumber: jest.fn(),
+      } as unknown as jest.Mocked<IGameStorage>;
 
       jest.clearAllMocks();
     });
 
-    // Test Scenario 1: No stored match data (no new match, no old round)
-    test("should initialize with null match state if no match or old round number is stored", () => {
-      // Explicitly set ALL necessary mock return values for this test scenario.
-      // The Model constructor will call these methods to determine initial state.
+    test("should load global match number even if there is no active match (Regression Test)", () => {
       constructorMockGameStorage.getMatch.mockReturnValue(null);
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(null);
-      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(null);
+      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(42);
 
-      // Initialize the model *after* setting up mocks for this specific test.
       constructorModel = new Model(constructorMockGameStorage);
 
       expect(constructorModel["state"].currentMatch).toBeNull();
-      expect(constructorModel["state"].globalMatchNumber).toBeNull();
+      expect(constructorModel["state"].globalMatchNumber).toBe(42);
 
       expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
       expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(
         constructorMockGameStorage.getGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(constructorMockGameStorage.setMatch).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
+      ).toHaveBeenCalledTimes(1);
     });
 
-    // Test Scenario 2: Resuming an Existing Match (New format)
-    test("should load existing match and global match number from storage", () => {
+    test("should load both active match and global match number from storage", () => {
       const existingMatch: Match = {
         matchRoundNumber: 3,
         playerHealth: 50,
@@ -1159,14 +1113,11 @@ describe("Model", () => {
       };
       const existingGlobalMatchNumber = 5;
 
-      // Set up specific mock return values *before* the model is re-initialized for this test
       constructorMockGameStorage.getMatch.mockReturnValue(existingMatch);
       constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(
         existingGlobalMatchNumber,
       );
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(null); // Explicitly ensure this is null for this path
 
-      // Re-initialize the model *after* setting up mocks for this specific test
       constructorModel = new Model(constructorMockGameStorage);
 
       expect(constructorModel["state"].currentMatch).toEqual(existingMatch);
@@ -1174,70 +1125,16 @@ describe("Model", () => {
         existingGlobalMatchNumber,
       );
 
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(2);
-      expect(
-        constructorMockGameStorage.getGlobalMatchNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled(); // Should NOT be called
-      expect(constructorMockGameStorage.setMatch).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
-    });
-
-    // Test Scenario 3: Migration from Old Global Round Number
-    test("should migrate old round number data to a new match object", () => {
-      const oldRoundNumber = 7;
-      constructorMockGameStorage.getMatch.mockReturnValue(null); // Ensure no new match
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(
-        oldRoundNumber,
-      ); // Old round number exists
-
-      // Re-initialize for this specific test's mocks
-      constructorModel = new Model(constructorMockGameStorage);
-
-      expect(constructorModel["state"].currentMatch).toEqual({
-        matchRoundNumber: oldRoundNumber,
-        playerHealth: INITIAL_HEALTH,
-        computerHealth: INITIAL_HEALTH,
-        initialHealth: INITIAL_HEALTH,
-        damagePerLoss: DAMAGE_PER_LOSS,
-      });
-      expect(constructorModel["state"].globalMatchNumber).toBe(1);
-
       expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
       expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(constructorMockGameStorage.setMatch).toHaveBeenCalledTimes(1);
-      expect(constructorMockGameStorage.setMatch).toHaveBeenCalledWith(
-        constructorModel["state"].currentMatch,
-      );
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(
         constructorMockGameStorage.getGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).toHaveBeenCalledWith(1);
     });
 
-    // Test Scenario 4: Old Global Round Number is Invalid (e.g., 0 or null from parse error)
-    test("should have no match data if old round number data is invalid or null", () => {
-      constructorMockGameStorage.getMatch.mockReturnValue(null); // Ensure no new match
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(0); // Simulate invalid old data
+    test("should initialize with null match and match number if storage is empty", () => {
+      constructorMockGameStorage.getMatch.mockReturnValue(null);
+      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(null);
 
-      // Re-initialize for this specific test's mocks
       constructorModel = new Model(constructorMockGameStorage);
 
       expect(constructorModel["state"].currentMatch).toBeNull();
@@ -1245,76 +1142,8 @@ describe("Model", () => {
 
       expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
       expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
-      expect(constructorMockGameStorage.setMatch).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.getGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-    });
-
-    // Test Scenario 5: Invalid Match Data (getMatch returns null due to parse error)
-    test("should initialize no match data if stored currentMatch data is invalid and no old round data exists", () => {
-      constructorMockGameStorage.getMatch.mockReturnValue(null); // Simulate parse error from storage
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(null); // No old data to fall back on
-
-      // Re-initialize for this specific test's mocks
-      constructorModel = new Model(constructorMockGameStorage);
-
-      expect(constructorModel["state"].currentMatch).toBeNull();
-      expect(constructorModel["state"].globalMatchNumber).toBeNull();
-
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(constructorMockGameStorage.setMatch).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
-    });
-
-    // Test Scenario 6: Global Match Number Data is Invalid (getGlobalMatchNumber returns default 1)
-    test("should still load active match, but default global match number if its data is invalid", () => {
-      const existingMatch: Match = {
-        matchRoundNumber: 1,
-        playerHealth: 100,
-        computerHealth: 100,
-      };
-
-      constructorMockGameStorage.getMatch.mockReturnValue(existingMatch);
-      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(1); // Simulate invalid data returning default 1
-      constructorMockGameStorage.getOldGlobalRoundNumber.mockReturnValue(null); // Not checked in this path
-
-      // Re-initialize for this specific test's mocks
-      constructorModel = new Model(constructorMockGameStorage);
-
-      expect(constructorModel["state"].currentMatch).toEqual(existingMatch);
-      expect(constructorModel["state"].globalMatchNumber).toBe(1);
-
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(2);
-      expect(
         constructorMockGameStorage.getGlobalMatchNumber,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
-      expect(constructorMockGameStorage.setMatch).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.setGlobalMatchNumber,
-      ).not.toHaveBeenCalled();
-      expect(
-        constructorMockGameStorage.removeOldGlobalRoundNumber,
-      ).not.toHaveBeenCalled();
     });
   });
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -71,7 +71,7 @@ export class Model {
       PARTICIPANTS.COMPUTER,
     );
 
-    this._loadOrMigrateMatchState();
+    this._loadMatchState();
   }
 
   // ===== General Methods =====
@@ -450,26 +450,9 @@ export class Model {
     this.setMatchNumber(this.getMatchNumber() + 1);
   }
 
-  private _loadOrMigrateMatchState(): void {
-    if (this.isMatchActive()) {
-      this.state.globalMatchNumber = this.gameStorage.getGlobalMatchNumber();
-      this.state.currentMatch = this.gameStorage.getMatch();
-      return;
-    }
-    const oldRound = this.gameStorage.getOldGlobalRoundNumber();
-    if (oldRound !== null && oldRound > 0) {
-      const match = {
-        matchRoundNumber: oldRound,
-        playerHealth: INITIAL_HEALTH,
-        computerHealth: INITIAL_HEALTH,
-        initialHealth: INITIAL_HEALTH,
-        damagePerLoss: DAMAGE_PER_LOSS,
-      };
-      this.setMatch(match);
-      this.gameStorage.removeOldGlobalRoundNumber();
-      this.state.globalMatchNumber = 1;
-      this.gameStorage.setGlobalMatchNumber(1);
-    }
+  private _loadMatchState(): void {
+    this.state.globalMatchNumber = this.gameStorage.getGlobalMatchNumber();
+    this.state.currentMatch = this.gameStorage.getMatch();
   }
 
   // ===== Health Methods =====

--- a/src/views/View.ts
+++ b/src/views/View.ts
@@ -3,6 +3,13 @@ export default abstract class View<T = any> {
   protected _parentElement!: HTMLElement;
 
   /**
+   * Returns true if the view has been provided with data.
+   */
+  public get hasData(): boolean {
+    return this._data !== undefined;
+  }
+
+  /**
    * Standard render method used by all views.
    *
    * @param data The state/data needed for the UI render.

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -11,7 +11,6 @@ export interface StatsViewData {
   computerMostCommonMove: Move | null;
   matchNumber: number;
   roundNumber: number;
-  isProgressVisible: boolean;
 }
 
 export interface IStatsView {

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -1,17 +1,22 @@
 import { Health, Move, Participant } from "../../utils/dataObjectUtils";
 
+export interface StatsViewData {
+  playerHealth: Health;
+  computerHealth: Health;
+  playerScore: number;
+  computerScore: number;
+  playerTara: number;
+  computerTara: number;
+  playerMostCommonMove: Move | null;
+  computerMostCommonMove: Move | null;
+  matchNumber: number;
+  roundNumber: number;
+  isProgressVisible: boolean;
+}
+
 export interface IStatsView {
+  render(data: StatsViewData): void;
+  update(data: StatsViewData): void;
+  readonly hasData: boolean;
   toggleGameStatsVisibility(show: boolean): void;
-  updateHealthBar(participant: Participant, health: Health): void;
-  updateMostCommonMoves(
-    playerMove: Move | null,
-    computerMove: Move | null,
-  ): void;
-  updateProgress(
-    matchNumber: number,
-    roundNumber: number,
-    isVisible: boolean,
-  ): void;
-  updateScores(playerScore: number, computerScore: number): void;
-  updateTaraCounts(playerTara: number, computerTara: number): void;
 }

--- a/src/views/stats/StatsView.test.ts
+++ b/src/views/stats/StatsView.test.ts
@@ -27,7 +27,6 @@ describe("StatsView", () => {
       computerMostCommonMove: null,
       matchNumber: 1,
       roundNumber: 1,
-      isProgressVisible: true,
     };
   });
 
@@ -127,25 +126,6 @@ describe("StatsView", () => {
         document.querySelector("#computer-stats small span:last-child")!
           .textContent,
       ).toBe(MOVES.PAPER);
-    });
-
-    test("toggles progress container visibility based on isProgressVisible", () => {
-      const progressContainer = document.getElementById(
-        "game-progress-container",
-      )!;
-
-      // Initially true (from beforeEach)
-      expect(progressContainer.classList.contains("hidden")).toBe(false);
-
-      // Update to false
-      view.update({ ...defaultData, isProgressVisible: false });
-      expect(progressContainer.classList.contains("hidden")).toBe(true);
-      expect(progressContainer.hasAttribute("inert")).toBe(true);
-
-      // Update back to true
-      view.update({ ...defaultData, isProgressVisible: true });
-      expect(progressContainer.classList.contains("hidden")).toBe(false);
-      expect(progressContainer.hasAttribute("inert")).toBe(false);
     });
   });
 });

--- a/src/views/stats/StatsView.test.ts
+++ b/src/views/stats/StatsView.test.ts
@@ -3,43 +3,38 @@
  */
 import { MOVES } from "../../utils/dataUtils";
 import StatsView from "./StatsView";
+import { StatsViewData } from "./IStatsView";
 
 describe("StatsView", () => {
   let view: StatsView;
+  let defaultData: StatsViewData;
 
   beforeEach(() => {
-    // Scaffold the full expected DOM for all StatsView methods
-    document.body.innerHTML = `
-      <section id="game-stats">
-        <aside id="player-stats">
-          <span id="player-score">00</span>
-          <div id="player-health"></div>
-          <span id="player-tara">0</span>
-          <span id="player-most-common-move">–</span>
-        </aside>
-        
-        <section id="game-progress-container">
-          <h2 id="match"></h2>
-          <h3 id="round"></h3>
-        </section>
-        
-        <aside id="computer-stats">
-          <span id="computer-score">00</span>
-          <div id="computer-health"></div>
-          <span id="computer-tara">0</span>
-          <span id="computer-most-common-move">–</span>
-        </aside>
-      </section>
-    `;
+    // 1. Scaffold only the mount point, just like the real index.html
+    document.body.innerHTML = `<section id="game-stats"></section>`;
 
     view = new StatsView();
 
-    // In StatsView, render() just hooks up the _parentElement
-    view.render();
+    // 2. Setup baseline data for rendering
+    defaultData = {
+      playerHealth: 100,
+      computerHealth: 100,
+      playerScore: 0,
+      computerScore: 0,
+      playerTara: 0,
+      computerTara: 0,
+      playerMostCommonMove: null,
+      computerMostCommonMove: null,
+      matchNumber: 1,
+      roundNumber: 1,
+      isProgressVisible: true,
+    };
   });
 
   describe("toggleGameStatsVisibility()", () => {
     test("adds or removes the hidden class on the main stats container", () => {
+      // Must render first so the parent element is cached
+      view.render(defaultData);
       const statsContainer = document.getElementById("game-stats")!;
 
       view.toggleGameStatsVisibility(false);
@@ -50,107 +45,107 @@ describe("StatsView", () => {
     });
   });
 
-  describe("updateProgress()", () => {
-    test("updates text content while preserving DOM nodes", () => {
-      const matchText = document.getElementById("match")!;
-      const roundText = document.getElementById("round")!;
+  describe("render()", () => {
+    test("generates and injects the full markup based on state", () => {
+      view.render(defaultData);
 
-      // Store current references to check persistence
-      const oldMatchRef = matchText;
-
-      view.updateProgress(2, 5, true);
-
-      expect(matchText.textContent).toBe("Match 2");
-      expect(roundText.textContent).toBe("Round 5");
-
-      // Verify node persistence (no innerHTML wiping)
-      expect(document.getElementById("match")).toBe(oldMatchRef);
+      expect(document.getElementById("player-health")!.style.width).toBe(
+        "100%",
+      );
+      expect(document.getElementById("computer-health")!.style.width).toBe(
+        "100%",
+      );
+      // Finds the <span> inside the score-row
+      expect(
+        document.querySelector("#player-stats .score-row span")!.textContent,
+      ).toBe("00");
+      expect(
+        document.querySelector("#game-progress-container h2")!.textContent,
+      ).toBe("Match 1");
     });
 
-    test("toggles visibility of the progress container", () => {
+    test("formats null common moves as '–'", () => {
+      view.render(defaultData);
+      // Fix: target the last span
+      expect(
+        document.querySelector("#player-stats small span:last-child")!
+          .textContent,
+      ).toBe("–");
+    });
+  });
+
+  describe("update()", () => {
+    beforeEach(() => {
+      // Render initial state to set up DOM for diffing
+      view.render(defaultData);
+    });
+
+    test("updates health bar width attributes without replacing elements", () => {
+      const oldPlayerHealthBar = document.getElementById("player-health")!;
+
+      const newData = { ...defaultData, playerHealth: 45, computerHealth: 12 };
+      view.update(newData);
+
+      const newPlayerHealthBar = document.getElementById("player-health")!;
+
+      expect(newPlayerHealthBar.style.width).toBe("45%");
+      expect(document.getElementById("computer-health")!.style.width).toBe(
+        "12%",
+      );
+
+      // Crucial check: ensures DOM diffing worked and didn't just wipe innerHTML
+      expect(newPlayerHealthBar).toBe(oldPlayerHealthBar);
+    });
+
+    test("updates scores and pads them correctly", () => {
+      const newData = { ...defaultData, playerScore: 5, computerScore: 12 };
+      view.update(newData);
+
+      expect(
+        document.querySelector("#player-stats .score-row span:first-child")!
+          .textContent,
+      ).toBe("05");
+      expect(
+        document.querySelector("#computer-stats .score-row span:last-child")!
+          .textContent,
+      ).toBe("12");
+    });
+
+    test("updates most common moves", () => {
+      const newData = {
+        ...defaultData,
+        playerMostCommonMove: MOVES.ROCK,
+        computerMostCommonMove: MOVES.PAPER,
+      };
+      view.update(newData);
+
+      expect(
+        document.querySelector("#player-stats small span:last-child")!
+          .textContent,
+      ).toBe(MOVES.ROCK);
+      expect(
+        document.querySelector("#computer-stats small span:last-child")!
+          .textContent,
+      ).toBe(MOVES.PAPER);
+    });
+
+    test("toggles progress container visibility based on isProgressVisible", () => {
       const progressContainer = document.getElementById(
         "game-progress-container",
       )!;
 
-      view.updateProgress(1, 1, false);
-      expect(progressContainer.classList.contains("hidden")).toBe(true);
-
-      view.updateProgress(1, 1, true);
+      // Initially true (from beforeEach)
       expect(progressContainer.classList.contains("hidden")).toBe(false);
-    });
-  });
 
-  describe("updateHealthBar()", () => {
-    test("updates the inline width style of the player health bar", () => {
-      view.updateHealthBar("player", 75);
-      const playerHealth = document.getElementById("player-health")!;
-      expect(playerHealth.style.width).toBe("75%");
-    });
+      // Update to false
+      view.update({ ...defaultData, isProgressVisible: false });
+      expect(progressContainer.classList.contains("hidden")).toBe(true);
+      expect(progressContainer.hasAttribute("inert")).toBe(true);
 
-    test("updates the inline width style of the computer health bar", () => {
-      view.updateHealthBar("computer", 40);
-      const computerHealth = document.getElementById("computer-health")!;
-      expect(computerHealth.style.width).toBe("40%");
-    });
-  });
-
-  describe("updateMostCommonMoves()", () => {
-    test("updates text content for both participants", () => {
-      view.updateMostCommonMoves(MOVES.ROCK, MOVES.PAPER);
-      expect(
-        document.getElementById("player-most-common-move")!.textContent,
-      ).toBe(MOVES.ROCK);
-      expect(
-        document.getElementById("computer-most-common-move")!.textContent,
-      ).toBe(MOVES.PAPER);
-    });
-
-    test("defaults to 'N/A' if null is passed", () => {
-      view.updateMostCommonMoves(null, null);
-      expect(
-        document.getElementById("player-most-common-move")!.textContent,
-      ).toBe("N/A");
-      expect(
-        document.getElementById("computer-most-common-move")!.textContent,
-      ).toBe("N/A");
-    });
-  });
-
-  describe("updateScores()", () => {
-    test("pads single-digit scores with a leading zero", () => {
-      view.updateScores(5, 9);
-      expect(document.getElementById("player-score")!.textContent).toBe("05");
-      expect(document.getElementById("computer-score")!.textContent).toBe("09");
-    });
-
-    test("does not pad double-digit scores", () => {
-      view.updateScores(12, 10);
-      expect(document.getElementById("player-score")!.textContent).toBe("12");
-      expect(document.getElementById("computer-score")!.textContent).toBe("10");
-    });
-
-    test("handles zero values correctly", () => {
-      view.updateScores(0, 0);
-      expect(document.getElementById("player-score")!.textContent).toBe("00");
-      expect(document.getElementById("computer-score")!.textContent).toBe("00");
-    });
-
-    test("throws an error if the DOM elements are missing", () => {
-      // Clear the DOM to simulate a broken state
-      document.body.innerHTML = "";
-
-      // Wrap in a function to test the error throw from _getElement
-      expect(() => {
-        view.updateScores(1, 1);
-      }).toThrow("Element #player-score not found.");
-    });
-  });
-
-  describe("updateTaraCounts()", () => {
-    test("updates text content with the correct counts", () => {
-      view.updateTaraCounts(3, 1);
-      expect(document.getElementById("player-tara")!.textContent).toBe("3");
-      expect(document.getElementById("computer-tara")!.textContent).toBe("1");
+      // Update back to true
+      view.update({ ...defaultData, isProgressVisible: true });
+      expect(progressContainer.classList.contains("hidden")).toBe(false);
+      expect(progressContainer.hasAttribute("inert")).toBe(false);
     });
   });
 });

--- a/src/views/stats/StatsView.ts
+++ b/src/views/stats/StatsView.ts
@@ -35,11 +35,7 @@ export default class StatsView
       computerMostCommonMove,
       matchNumber,
       roundNumber,
-      isProgressVisible,
     } = this._data;
-
-    const progressClass = isProgressVisible ? "" : "hidden";
-    const progressInert = isProgressVisible ? "" : "inert";
 
     return `
       <aside id="player-stats" class="stats">
@@ -52,7 +48,7 @@ export default class StatsView
         <p><small><span>Common: </span><span>${playerMostCommonMove ?? "–"}</span></small></p>
       </aside>
 
-      <section id="game-progress-container" class="${progressClass}" ${progressInert}>
+      <section id="game-progress-container">
         <h2>Match ${matchNumber}</h2>
         <h3>Round ${roundNumber}</h3>
       </section>

--- a/src/views/stats/StatsView.ts
+++ b/src/views/stats/StatsView.ts
@@ -1,123 +1,71 @@
 import View from "../View";
-import { IStatsView } from "./IStatsView";
-import { Health, Participant, StandardMove } from "../../utils/dataObjectUtils";
+import { IStatsView, StatsViewData } from "./IStatsView";
 
-export default class StatsView extends View implements IStatsView {
+export default class StatsView
+  extends View<StatsViewData>
+  implements IStatsView
+{
   declare protected _parentElement: HTMLElement;
 
-  private get _computerHealthBarElement() {
-    return this._getElement<HTMLElement>("computer-health");
+  private _ensureParentElement(): void {
+    if (!this._parentElement || !document.body.contains(this._parentElement)) {
+      this._parentElement = this._getElement<HTMLElement>("game-stats");
+    }
   }
 
-  private get _computerMostCommonMoveElement() {
-    return this._getElement<HTMLElement>("computer-most-common-move");
+  public render(data: StatsViewData): void {
+    this._ensureParentElement();
+    super.render(data);
   }
 
-  private get _computerScoreElement() {
-    return this._getElement<HTMLElement>("computer-score");
-  }
-
-  private get _computerTaraCountElement() {
-    return this._getElement<HTMLElement>("computer-tara");
-  }
-
-  private get _matchElement() {
-    return this._getElement<HTMLElement>("match");
-  }
-
-  private get _playerHealthBarElement() {
-    return this._getElement<HTMLElement>("player-health");
-  }
-
-  private get _playerMostCommonMoveElement() {
-    return this._getElement<HTMLElement>("player-most-common-move");
-  }
-
-  private get _playerScoreElement() {
-    return this._getElement<HTMLElement>("player-score");
-  }
-
-  private get _playerTaraCountElement() {
-    return this._getElement<HTMLElement>("player-tara");
-  }
-
-  private get _progressContainerElement() {
-    return this._getElement<HTMLElement>("game-progress-container");
-  }
-
-  private get _roundElement() {
-    return this._getElement<HTMLElement>("round");
-  }
-
-  // ===== General Methods =====
-
-  // Satisfy the abstract requirement without doing anything
-  protected _generateMarkup(): string {
-    return "";
-  }
-
-  public render(): void {
-    this._parentElement = this._getElement<HTMLElement>("game-stats");
-
-    // DO NOT call super.render().
-    // Calling super.render() triggers _clear()
-  }
-
-  public toggleGameStatsVisibility(show: boolean) {
-    this._parentElement = this._getElement("game-stats");
+  public toggleGameStatsVisibility(show: boolean): void {
+    this._ensureParentElement();
     this._toggleVisibility(this._parentElement, show);
   }
 
-  // ===== Health Methods =====
+  protected _generateMarkup(): string {
+    const {
+      playerHealth,
+      computerHealth,
+      playerScore,
+      computerScore,
+      playerTara,
+      computerTara,
+      playerMostCommonMove,
+      computerMostCommonMove,
+      matchNumber,
+      roundNumber,
+      isProgressVisible,
+    } = this._data;
 
-  public updateHealthBar(participant: Participant, health: Health): void {
-    const bar = this._getHealthBar(participant);
+    const progressClass = isProgressVisible ? "" : "hidden";
+    const progressInert = isProgressVisible ? "" : "inert";
 
-    // Directly set width percentage
-    bar.style.width = `${health}%`;
-  }
+    return `
+      <aside id="player-stats" class="stats">
+        <div class="score-row"><span>${playerScore.toString().padStart(2, "0")}</span> <span>WINS</span></div>
+        <div class="bar-wrapper">
+          <div class="bar" id="player-health" style="width: ${playerHealth}%"></div>
+          <span class="bar-text">PLAYER</span>
+        </div>
+        <p><span>Tara x</span><span>${playerTara}</span></p>
+        <p><small><span>Common: </span><span>${playerMostCommonMove ?? "–"}</span></small></p>
+      </aside>
 
-  private _getHealthBar(participant: Participant): HTMLElement {
-    return participant === "player"
-      ? this._playerHealthBarElement
-      : this._computerHealthBarElement;
-  }
+      <section id="game-progress-container" class="${progressClass}" ${progressInert}>
+        <h2>Match ${matchNumber}</h2>
+        <h3>Round ${roundNumber}</h3>
+      </section>
 
-  // ===== History Methods =====
-
-  updateMostCommonMoves(
-    player: StandardMove | null,
-    computer: StandardMove | null,
-  ): void {
-    this._playerMostCommonMoveElement.textContent = player ?? "N/A";
-    this._computerMostCommonMoveElement.textContent = computer ?? "N/A";
-  }
-
-  // ===== Progress Methods =====
-
-  public updateProgress(
-    matchNumber: number,
-    roundNumber: number,
-    isVisible: boolean,
-  ): void {
-    this._matchElement.textContent = `Match ${matchNumber}`;
-    this._roundElement.textContent = `Round ${roundNumber}`;
-    this._toggleVisibility(this._progressContainerElement, isVisible);
-  }
-
-  // ===== Score Methods =====
-
-  public updateScores(player: number, computer: number): void {
-    this._playerScoreElement.textContent = player!.toString().padStart(2, "0");
-    this._computerScoreElement.textContent = computer!
-      .toString()
-      .padStart(2, "0");
-  }
-
-  // ===== Tara Methods =====
-
-  updateTaraCounts(playerCount: number, computerCount: number): void {
-    this._playerTaraCountElement.textContent = playerCount.toString();
-    this._computerTaraCountElement.textContent = computerCount.toString();
+      <aside id="computer-stats" class="stats">
+        <div class="score-row"><span>WINS</span> <span>${computerScore.toString().padStart(2, "0")}</span></div>
+        <div class="bar-wrapper">
+          <div class="bar" id="computer-health" style="width: ${computerHealth}%"></div>
+          <span class="bar-text">COMPUTER</span>
+        </div>
+        <p><span>Tara x</span><span>${computerTara}</span></p>
+        <p><small><span>Common: </span><span>${computerMostCommonMove ?? "–"}</span></small></p>
+      </aside>
+    `;
   }
 }


### PR DESCRIPTION
**Summary of Technical Changes:**
- **Base Migration:** Changed `StatsView` to leverage it's extension of the application's base `View` class, truly inheriting core state tracking (`this._data`), `.render()`, and DOM-diffing `.update()` capabilities.
- **Declarative Markup:** Implemented the protected `_generateMarkup()` method to consolidate the stats layout, progress trackers, and health bars into a unified HTML template.
- **Deprecation of Manual Updates:** Removed manual view methods (`updateScores`, `updateHealthBar`, etc.) from the `IStatsView` interface, shifting data rendering responsibilities entirely onto the controller calling standard state updates.
- **Initialization Alignment:** Replaced the legacy `_loadOrMigrateMatchState` logic in the Model with a simplified, linear `_loadMatchState` routine. This addresses a lifecycle edge case uncovered during the refactor where the global match number could temporarily default to "1" on initialization if a match wasn't already active in storage.
- **Test Suite Alignment:** Updated StatsView, Controller, and Model unit tests to reflect the new interface contract. Removed deprecated migration tests and added a regression test to guarantee the global match number initializes predictably regardless of immediate match state activity.

**Testing Notes:**

- All automated unit tests passed for both the view rendering logic, model state loading, and controller integration.
- Verified manually that the correct match number persists and renders instantly upon page reload.