### PR TITLE
RPST-84: feat: implement round evaluation logic in controller

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -143,6 +143,11 @@ describe("Controller", () => {
 
   describe("handlePlayerMove", () => {
     test("executes the full combat sequence", async () => {
+      (mockModel.evaluateRound as jest.Mock).mockReturnValue({
+        winner: "player",
+        damageCalculated: 50,
+      });
+
       await controller.handlePlayerMove(MOVES.ROCK);
 
       expect(mockModel.registerPlayerMove).toHaveBeenCalledWith(MOVES.ROCK);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -162,47 +162,41 @@ export class Controller {
   }
 
   async handlePlayerMove(move: Move): Promise<void> {
-    // Let the computer choose based on PREVIOUS history
+    // Let the computer choose based on PREVIOUS round data, before we record the player's current move
     this.model.chooseComputerMove();
 
-    // Record the player's move for NEXT round's calculations
+    // Record the player's move for THIS round's calculations
     this.model.registerPlayerMove(move);
 
     // 1. Preparation
     this.statusView.setMessage("Locking in move...");
     await this.controlsView.flipAll(false);
 
+    // 2. Fetch data from the Model for the upcoming round
     const pMove = this.model.getPlayerMove();
     const cMove = this.model.getComputerMove();
-    const roundResult = this.model.evaluateRound();
     const isDoubleKO = this.model.isDoubleKO();
-
-    let winner: Participant | "tie" = "tie";
-    if (pMove !== cMove) {
-      winner = this.model.doesMoveBeat(pMove, cMove)
-        ? PARTICIPANTS.PLAYER
-        : PARTICIPANTS.COMPUTER;
-    }
+    const roundResult = this.model.evaluateRound();
 
     this.statusView.setMessage(
-      `You played ${MOVE_DISPLAY_NAMES[this.model.getPlayerMove()]}. Computer played ${MOVE_DISPLAY_NAMES[this.model.getComputerMove()]}.`,
+      `You played ${MOVE_DISPLAY_NAMES[pMove]}. Computer played ${MOVE_DISPLAY_NAMES[cMove]}.`,
     );
 
-    // 2. Play out the entire visual sequence via the View
+    // 3. Play out the entire visual sequence via the View
     await this.arenaView.playRoundSequence({
       phase: "waiting", // Starting state, the View will progress this
       playerMoveId: pMove,
       computerMoveId: cMove,
-      winner: winner,
+      winner: roundResult.winner,
       isDoubleKO: isDoubleKO,
       announcementMessage: isDoubleKO
         ? "MUTUAL DESTRUCTION!"
-        : winner !== "tie"
-          ? `${winner.toUpperCase()} LANDS A BLOW!`
-          : roundResult.toUpperCase(),
+        : roundResult.winner !== "tie"
+          ? `${roundResult.winner.toUpperCase()} LANDS A BLOW!`
+          : "IT'S A TIE!",
     });
 
-    // 3. Process game logic end-of-round
+    // 4. Process game logic end-of-round
     this.updateStatsView();
     this.endRound();
   }

--- a/src/model/IModel.ts
+++ b/src/model/IModel.ts
@@ -1,4 +1,10 @@
-import { Health, Match, Move, Participant } from "../utils/dataObjectUtils";
+import {
+  Health,
+  Match,
+  Move,
+  Participant,
+  RoundResult,
+} from "../utils/dataObjectUtils";
 
 export interface IModel {
   // Score
@@ -13,7 +19,7 @@ export interface IModel {
   getComputerMove(): Move;
   registerPlayerMove(move: Move): void;
   chooseComputerMove(): void;
-  evaluateRound(): string;
+  evaluateRound(): RoundResult;
   resetMoves(): void;
 
   // Tara

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -1,9 +1,13 @@
 import { Model } from "./model";
 import {
   DAMAGE_PER_LOSS,
+  DAMAGE_PER_TARA_LOSS,
+  DAMAGE_PER_TARA_TIE,
+  DAMAGE_PER_TIE,
   DEFAULT_MATCH,
   DEFAULT_MATCH_NUMBER,
   INITIAL_HEALTH,
+  INITIAL_ROUND_NUMBER,
   MOVES,
   PARTICIPANTS,
   STANDARD_MOVE_DATA_MAP,
@@ -177,37 +181,50 @@ describe("Model", () => {
   });
 
   describe("evaluateRound", () => {
-    test("returns 'Invalid round' if player move is missing", () => {
+    test("throws an error if player move is missing", () => {
       model.setComputerMove(MOVES.ROCK);
-      expect(model.evaluateRound()).toBe("Invalid round");
+      expect(() => model.evaluateRound()).toThrow(
+        "Cannot evaluate round with missing moves.",
+      );
     });
 
-    test("returns 'Invalid round' if computer move is missing", () => {
+    test("throws an error if computer move is missing", () => {
       model.setPlayerMove(MOVES.PAPER);
-      expect(model.evaluateRound()).toBe("Invalid round");
+      expect(() => model.evaluateRound()).toThrow(
+        "Cannot evaluate round with missing moves.",
+      );
     });
 
     test("does not update scores on tie", () => {
       model.setPlayerMove(MOVES.SCISSORS);
       model.setComputerMove(MOVES.SCISSORS);
 
-      expect(model.evaluateRound()).toBe("It's a tie!");
+      expect(model.evaluateRound()).toEqual({
+        winner: "tie",
+        damageCalculated: DAMAGE_PER_TIE,
+      });
       expect(model.getPlayerScore()).toBe(0);
       expect(model.getComputerScore()).toBe(0);
     });
 
-    test("returns 'You win the round!' if player beats computer and updates score", () => {
+    test("returns correct winner and damage if player beats computer", () => {
       model.setPlayerMove(MOVES.ROCK);
       model.setComputerMove(MOVES.SCISSORS);
 
-      expect(model.evaluateRound()).toBe("You win the round!");
+      expect(model.evaluateRound()).toEqual({
+        winner: PARTICIPANTS.PLAYER,
+        damageCalculated: DAMAGE_PER_LOSS,
+      });
     });
 
-    test("returns 'Computer wins the round!' if computer beats player and updates score", () => {
+    test("returns correct winner and damage if computer beats player", () => {
       model.setPlayerMove(MOVES.PAPER);
       model.setComputerMove(MOVES.SCISSORS);
 
-      expect(model.evaluateRound()).toBe("Computer wins the round!");
+      expect(model.evaluateRound()).toEqual({
+        winner: PARTICIPANTS.COMPUTER,
+        damageCalculated: DAMAGE_PER_LOSS,
+      });
     });
   });
 
@@ -292,7 +309,11 @@ describe("Model", () => {
       model.setPlayerMove(MOVES.TARA);
       model.setComputerMove(MOVES.TARA);
 
-      expect(model.evaluateRound()).toBe("It's a tie!");
+      // Both mutated to ROCK, making it a standard tie
+      expect(model.evaluateRound()).toEqual({
+        winner: "tie",
+        damageCalculated: DAMAGE_PER_TIE,
+      });
       expect(model.getPlayerMove()).toBe(MOVES.ROCK);
       expect(model.getComputerMove()).toBe(MOVES.ROCK);
     });
@@ -304,7 +325,10 @@ describe("Model", () => {
       model.setPlayerMove(MOVES.TARA);
       model.setComputerMove(MOVES.TARA);
 
-      expect(model.evaluateRound()).toBe("It's a tie!");
+      expect(model.evaluateRound()).toEqual({
+        winner: "tie",
+        damageCalculated: DAMAGE_PER_TARA_TIE,
+      });
       expect(model.getPlayerScore()).toBe(0);
       expect(model.getComputerScore()).toBe(0);
     });
@@ -315,7 +339,10 @@ describe("Model", () => {
 
         model.setPlayerMove(MOVES.TARA);
         model.setComputerMove(move);
-        expect(model.evaluateRound()).toBe("You win the round!");
+        expect(model.evaluateRound()).toEqual({
+          winner: PARTICIPANTS.PLAYER,
+          damageCalculated: DAMAGE_PER_TARA_LOSS,
+        });
       }
     });
 
@@ -325,7 +352,10 @@ describe("Model", () => {
 
         model.setPlayerMove(move);
         model.setComputerMove(MOVES.TARA);
-        expect(model.evaluateRound()).toBe("Computer wins the round!");
+        expect(model.evaluateRound()).toEqual({
+          winner: PARTICIPANTS.COMPUTER,
+          damageCalculated: DAMAGE_PER_TARA_LOSS,
+        });
       }
     });
 
@@ -885,17 +915,14 @@ describe("Model", () => {
       model.setPlayerMove(MOVES.ROCK);
       model.setComputerMove(MOVES.SCISSORS);
 
-      // Verify initial state
-      expect(model["state"].currentMatch?.computerHealth).toBe(INITIAL_HEALTH);
-      expect(model["state"].currentMatch?.playerHealth).toBe(INITIAL_HEALTH);
+      expect(model.evaluateRound()).toEqual({
+        winner: PARTICIPANTS.PLAYER,
+        damageCalculated: DAMAGE_PER_LOSS,
+      });
 
-      expect(model.evaluateRound()).toBe("You win the round!");
-
-      // Verify health updates as expected
       expect(model["state"].currentMatch?.computerHealth).toBe(
         INITIAL_HEALTH - DAMAGE_PER_LOSS,
       );
-      expect(model["state"].currentMatch?.playerHealth).toBe(INITIAL_HEALTH);
     });
 
     test("decrements player's health when computer wins round", () => {
@@ -903,17 +930,14 @@ describe("Model", () => {
       model.setComputerMove(MOVES.PAPER);
       model.setPlayerMove(MOVES.ROCK);
 
-      // Verify initial state
-      expect(model["state"].currentMatch?.playerHealth).toBe(INITIAL_HEALTH);
-      expect(model["state"].currentMatch?.computerHealth).toBe(INITIAL_HEALTH);
+      expect(model.evaluateRound()).toEqual({
+        winner: PARTICIPANTS.COMPUTER,
+        damageCalculated: DAMAGE_PER_LOSS,
+      });
 
-      expect(model.evaluateRound()).toBe("Computer wins the round!");
-
-      // Verify health updates as expected
       expect(model["state"].currentMatch?.playerHealth).toBe(
         INITIAL_HEALTH - DAMAGE_PER_LOSS,
       );
-      expect(model["state"].currentMatch?.computerHealth).toBe(INITIAL_HEALTH);
     });
 
     test("returns false if both participants have health > 0", () => {
@@ -1074,35 +1098,43 @@ describe("Model", () => {
   });
 
   describe("Model Constructor - State Initialization", () => {
-    let constructorMockGameStorage: jest.Mocked<IGameStorage>;
-    let constructorModel: Model;
+    let mockGameStorage: jest.Mocked<IGameStorage>;
+    let model: Model;
 
     beforeEach(() => {
-      constructorMockGameStorage = {
+      // We create a fully implemented mock to prevent "is not a function" errors
+      // when the Model constructor runs immediately upon instantiation.
+      mockGameStorage = {
         getScore: jest.fn(() => 0),
         getTaraCount: jest.fn(() => 0),
         getMostCommonMove: jest.fn(() => null),
         getMoveCounts: jest.fn(() => ({ rock: 0, paper: 0, scissors: 0 })),
-        getMatch: jest.fn(),
-        getGlobalMatchNumber: jest.fn(),
+        getMatch: jest.fn(() => null),
+        getGlobalMatchNumber: jest.fn(() => null),
       } as unknown as jest.Mocked<IGameStorage>;
 
       jest.clearAllMocks();
     });
 
-    test("should load global match number even if there is no active match (Regression Test)", () => {
-      constructorMockGameStorage.getMatch.mockReturnValue(null);
-      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(42);
+    test("initializes with the correct default match state", () => {
+      mockGameStorage.getMatch.mockReturnValue(null);
+      model = new Model(mockGameStorage);
 
-      constructorModel = new Model(constructorMockGameStorage);
+      expect(model.getHealth(PARTICIPANTS.PLAYER)).toBe(INITIAL_HEALTH);
+      expect(model.getHealth(PARTICIPANTS.COMPUTER)).toBe(INITIAL_HEALTH);
+      expect(model.getPlayerTaraCount()).toBe(0);
+      expect(model.getComputerTaraCount()).toBe(0);
+      expect(model.getRoundNumber()).toBe(INITIAL_ROUND_NUMBER);
+    });
 
-      expect(constructorModel["state"].currentMatch).toBeNull();
-      expect(constructorModel["state"].globalMatchNumber).toBe(42);
+    test("should load global match number even if there is no active match", () => {
+      mockGameStorage.getMatch.mockReturnValue(null);
+      mockGameStorage.getGlobalMatchNumber.mockReturnValue(42);
 
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getGlobalMatchNumber,
-      ).toHaveBeenCalledTimes(1);
+      model = new Model(mockGameStorage);
+
+      expect(model["state"].currentMatch).toBeNull();
+      expect(model["state"].globalMatchNumber).toBe(42);
     });
 
     test("should load both active match and global match number from storage", () => {
@@ -1111,89 +1143,23 @@ describe("Model", () => {
         playerHealth: 50,
         computerHealth: 100,
       };
-      const existingGlobalMatchNumber = 5;
+      mockGameStorage.getMatch.mockReturnValue(existingMatch);
+      mockGameStorage.getGlobalMatchNumber.mockReturnValue(5);
 
-      constructorMockGameStorage.getMatch.mockReturnValue(existingMatch);
-      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(
-        existingGlobalMatchNumber,
-      );
+      model = new Model(mockGameStorage);
 
-      constructorModel = new Model(constructorMockGameStorage);
-
-      expect(constructorModel["state"].currentMatch).toEqual(existingMatch);
-      expect(constructorModel["state"].globalMatchNumber).toBe(
-        existingGlobalMatchNumber,
-      );
-
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getGlobalMatchNumber,
-      ).toHaveBeenCalledTimes(1);
+      expect(model["state"].currentMatch).toEqual(existingMatch);
+      expect(model["state"].globalMatchNumber).toBe(5);
     });
 
     test("should initialize with null match and match number if storage is empty", () => {
-      constructorMockGameStorage.getMatch.mockReturnValue(null);
-      constructorMockGameStorage.getGlobalMatchNumber.mockReturnValue(null);
+      mockGameStorage.getMatch.mockReturnValue(null);
+      mockGameStorage.getGlobalMatchNumber.mockReturnValue(null);
 
-      constructorModel = new Model(constructorMockGameStorage);
+      model = new Model(mockGameStorage);
 
-      expect(constructorModel["state"].currentMatch).toBeNull();
-      expect(constructorModel["state"].globalMatchNumber).toBeNull();
-
-      expect(constructorMockGameStorage.getMatch).toHaveBeenCalledTimes(1);
-      expect(
-        constructorMockGameStorage.getGlobalMatchNumber,
-      ).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("Model Damage Calculation", () => {
-    test("deals DAMAGE_PER_TIE to both players on a standard tie", () => {
-      model.setMatch({
-        ...DEFAULT_MATCH,
-        playerHealth: 100,
-        computerHealth: 100,
-      });
-      model.setPlayerMove(MOVES.ROCK);
-      model.setComputerMove(MOVES.ROCK);
-
-      model.evaluateRound();
-
-      expect(model.getHealth(PARTICIPANTS.PLAYER)).toBe(90); // 100 - 10
-      expect(model.getHealth(PARTICIPANTS.COMPUTER)).toBe(90);
-    });
-
-    test("deals DAMAGE_PER_TARA_TIE on a double Tara move", () => {
-      model.setMatch({
-        ...DEFAULT_MATCH,
-        playerHealth: 100,
-        computerHealth: 100,
-      });
-      model.setPlayerTaraCount(1);
-      model.setComputerTaraCount(1);
-      model.setPlayerMove(MOVES.TARA);
-      model.setComputerMove(MOVES.TARA);
-
-      model.evaluateRound();
-
-      expect(model.getHealth(PARTICIPANTS.PLAYER)).toBe(80); // 100 - 20
-      expect(model.getHealth(PARTICIPANTS.COMPUTER)).toBe(80);
-    });
-
-    test("identifies a Double KO when both players hit 0 health", () => {
-      // Start both at 10 health
-      model.setMatch({
-        ...DEFAULT_MATCH,
-        playerHealth: 10,
-        computerHealth: 10,
-      });
-      model.setPlayerMove(MOVES.ROCK);
-      model.setComputerMove(MOVES.ROCK);
-
-      model.evaluateRound(); // Standard tie deals 10 damage
-
-      expect(model.isDoubleKO()).toBe(true);
-      expect(model.getMatchWinner()).toBe("draw");
+      expect(model["state"].currentMatch).toBeNull();
+      expect(model["state"].globalMatchNumber).toBeNull();
     });
   });
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -21,6 +21,7 @@ import {
 } from "../utils/dataUtils";
 import { IComputerBrain } from "../utils/computer/IComputerBrain";
 import { AdaptiveComputer } from "../utils/computer/AdaptiveComputer";
+import { RoundResult } from "../utils/dataObjectUtils";
 import { IGameStorage } from "../storage/gameStorage";
 import { LocalStorageGameStorage } from "../storage/localStorageGameStorage";
 
@@ -89,36 +90,64 @@ export class Model {
     }
   }
 
-  evaluateRound(): string {
-    let playerMove = this.getPlayerMove();
-    let computerMove = this.getComputerMove();
-    if (playerMove === null || computerMove === null) return "Invalid round";
+  private determineWinner(
+    playerMove: Move,
+    computerMove: Move,
+  ): Participant | "tie" {
+    if (playerMove === computerMove) return "tie";
 
-    this.handleTaraMove(PARTICIPANTS.PLAYER, playerMove);
-    this.handleTaraMove(PARTICIPANTS.COMPUTER, computerMove);
+    return this.doesMoveBeat(playerMove, computerMove)
+      ? PARTICIPANTS.PLAYER
+      : PARTICIPANTS.COMPUTER;
+  }
 
-    playerMove = this.getPlayerMove();
-    computerMove = this.getComputerMove();
-
-    const tieStatus = this.isTie();
-    const taraInPlay = playerMove === MOVES.TARA || computerMove === MOVES.TARA;
-    const damage = this.getDamageAmount(tieStatus, taraInPlay);
-
-    if (tieStatus) {
+  private applyRoundResults(
+    winner: Participant | "tie",
+    pMove: Move,
+    cMove: Move,
+    damage: number,
+  ): void {
+    if (winner === "tie") {
       this.decrementHealth(PARTICIPANTS.PLAYER, damage);
       this.decrementHealth(PARTICIPANTS.COMPUTER, damage);
-      return "It's a tie!";
+      return;
     }
 
-    if (this.doesMoveBeat(playerMove!, computerMove!)) {
-      this.handleRoundWin(PARTICIPANTS.PLAYER, playerMove!);
-      this.decrementHealth(PARTICIPANTS.COMPUTER, damage);
-      return "You win the round!";
-    } else {
-      this.handleRoundWin(PARTICIPANTS.COMPUTER, computerMove!);
-      this.decrementHealth(PARTICIPANTS.PLAYER, damage);
-      return "Computer wins the round!";
+    const winningMove = winner === PARTICIPANTS.PLAYER ? pMove : cMove;
+    const loser =
+      winner === PARTICIPANTS.PLAYER
+        ? PARTICIPANTS.COMPUTER
+        : PARTICIPANTS.PLAYER;
+
+    this.handleRoundWin(winner, winningMove);
+    this.decrementHealth(loser, damage);
+  }
+
+  evaluateRound(): RoundResult {
+    const rawPlayerMove = this.getPlayerMove();
+    const rawComputerMove = this.getComputerMove();
+
+    if (!rawPlayerMove || !rawComputerMove) {
+      throw new Error("Cannot evaluate round with missing moves.");
     }
+
+    // Step 1: Validate intended moves (Handles Tara consumption/penalties)
+    const pMove = this.getEffectiveMove(PARTICIPANTS.PLAYER, rawPlayerMove);
+    const cMove = this.getEffectiveMove(PARTICIPANTS.COMPUTER, rawComputerMove);
+
+    // Step 2: Calculate the outcome
+    const winner = this.determineWinner(pMove, cMove);
+    const taraInPlay = pMove === MOVES.TARA || cMove === MOVES.TARA;
+    const damage = this.getDamageAmount(winner === "tie", taraInPlay);
+
+    // Step 3: Apply the outcome to the Model's state
+    this.applyRoundResults(winner, pMove, cMove, damage);
+
+    // Step 4: Return pure data for the Controller/View to use
+    return {
+      winner,
+      damageCalculated: damage,
+    };
   }
 
   isMatchActive(): boolean {
@@ -341,15 +370,21 @@ export class Model {
     }
   }
 
-  private handleTaraMove(key: Participant, move: Move): void {
-    if (move === MOVES.TARA) {
-      const currentTara = this.getTaraCount(key);
-      if (currentTara > 0) {
-        this.decrementTaraCount(key);
-      } else {
-        this.setMove(key, MOVES.ROCK);
-      }
+  /**
+   * Checks if a Tara move is valid. If valid, consumes a charge.
+   * If invalid (no charges left), forces the move to ROCK as a fallback.
+   */
+  private getEffectiveMove(participant: Participant, intendedMove: Move): Move {
+    if (intendedMove !== MOVES.TARA) return intendedMove;
+
+    if (this.getTaraCount(participant) > 0) {
+      this.decrementTaraCount(participant);
+      return MOVES.TARA; // Valid Tara
     }
+
+    // Invalid Tara! Force fallback to Rock and update the state to match.
+    this.setMove(participant, MOVES.ROCK);
+    return MOVES.ROCK;
   }
 
   private setTaraCount(key: Participant, value: number): void {
@@ -459,19 +494,19 @@ export class Model {
 
   getHealth(participant: Participant): Health {
     const match = this.state.currentMatch;
-    if (!match) return null;
+    if (!match) return INITIAL_HEALTH;
     const value = match[HEALTH_KEYS[participant]];
-    return value !== undefined && value !== null ? value : null;
+    return value !== undefined && value !== null ? value : INITIAL_HEALTH;
   }
 
-  private getDamageAmount(
-    isTie: boolean | "tara-tie",
-    taraInPlay: boolean,
-  ): number {
-    if (isTie === "tara-tie") return DAMAGE_PER_TARA_TIE;
-    if (isTie) return DAMAGE_PER_TIE;
-    if (taraInPlay) return DAMAGE_PER_TARA_LOSS;
-    return DAMAGE_PER_LOSS;
+  private getDamageAmount(isTie: boolean, taraInPlay: boolean): number {
+    if (isTie) {
+      // If it's a tie AND Tara is in play, they both played Tara
+      return taraInPlay ? DAMAGE_PER_TARA_TIE : DAMAGE_PER_TIE;
+    } else {
+      // If it's a win/loss AND Tara is in play, someone took Tara damage
+      return taraInPlay ? DAMAGE_PER_TARA_LOSS : DAMAGE_PER_LOSS;
+    }
   }
 
   private decrementHealth(participant: Participant, damage: number): boolean {

--- a/src/utils/dataObjectUtils.ts
+++ b/src/utils/dataObjectUtils.ts
@@ -14,6 +14,25 @@ export type MoveData = {
 
 export type MoveCount = Record<StandardMove, number>;
 
+/**
+ * Represents the pure data outcome of a single game round.
+ * * @remarks
+ * Returning this object from the Model keeps formatting and presentation
+ * logic strictly out of the business layer.
+ */
+export interface RoundResult {
+  /**
+   * The participant who won the round, or `"tie"` if it was a draw.
+   */
+  winner: Participant | "tie";
+
+  /**
+   * The amount of health deducted from the losing participant(s).
+   * In the event of a tie, this damage is applied to both participants.
+   */
+  damageCalculated: number;
+}
+
 export type VoidHandler = () => void;
 
 export interface Match {


### PR DESCRIPTION
Implements the core round evaluation logic within the Controller. It enables the transition from receiving user input to calculating the round outcome and updating the Model.

**Key Changes:**
- Added logic to process handlePlayerMove in the Controller.
- Integrated winner calculation and damage application.
- Ensured the Model provides safe defaults for all health and round data, preventing null references during calculation.

**Testing Done:**
- Updated Model unit tests to ensure getHealth and other getters provide `INITIAL_HEALTH` defaults.
- Verified full game loop (Move -> Evaluation -> State Update) via manual testing.