### PR TITLE
RPST-86: refactor: encapsulate game reset state sequence inside Model

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -51,11 +51,7 @@ describe("Controller", () => {
       doesMoveBeat: jest.fn().mockReturnValue(true),
       setMatch: jest.fn(),
       isMatchActive: jest.fn().mockReturnValue(false),
-      resetScores: jest.fn(),
-      resetTaras: jest.fn(),
-      resetBothMoveCounts: jest.fn(),
-      resetMostCommonMoves: jest.fn(),
-      resetMatchData: jest.fn(),
+      resetGame: jest.fn(),
     } as any;
 
     // 2. Setup Mock Views
@@ -159,11 +155,8 @@ describe("Controller", () => {
     test("completely wipes model data and refreshes all views", async () => {
       await controller.resetGameState();
 
-      expect(mockModel.resetScores).toHaveBeenCalled();
-      expect(mockModel.resetMatchData).toHaveBeenCalled();
-
+      expect(mockModel.resetGame).toHaveBeenCalled();
       expect(mockViews.statsView.render).toHaveBeenCalled();
-
       expect(mockViews.arenaView.clear).toHaveBeenCalled();
       expect(mockViews.controlsView.toggleVisibility).toHaveBeenCalledWith(
         false,

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -127,25 +127,20 @@ export class Controller {
   }
 
   private async handleNextRound(): Promise<void> {
+    this.statusView.setMessage("Prepare your next move...");
+
     this.model.resetMoves();
 
     this.arenaView.clear();
-
     this.updateControlsView();
     this.updateStatsView();
-
-    this.statusView.setMessage("Prepare your next move...");
 
     await this.controlsView.flipAll(true);
     this.statusView.setMessage("Choose your attack!");
   }
 
   async resetGameState(): Promise<void> {
-    this.model.resetScores();
-    this.model.resetTaras();
-    this.model.resetBothMoveCounts();
-    this.model.resetMostCommonMoves();
-    this.model.resetMatchData();
+    this.model.resetGame();
 
     this.menuView.updateMenu({ isMatchActive: false });
     this.menuView.bindStartMatch(() => this.startGame());

--- a/src/model/IModel.ts
+++ b/src/model/IModel.ts
@@ -26,13 +26,10 @@ export interface IModel {
   getPlayerTaraCount(): number;
   getComputerTaraCount(): number;
   taraIsEnabled(): boolean;
-  resetTaras(): void;
 
   // Most common moves
   getPlayerMostCommonMove(): Move | null;
   getComputerMostCommonMove(): Move | null;
-  resetBothMoveCounts(): void;
-  resetMostCommonMoves(): void;
   showMostCommonMove(): boolean;
 
   // Match & round
@@ -46,11 +43,10 @@ export interface IModel {
   getMatchNumber(): number;
   setMatch(match: Match | null): void;
   setDefaultMatchData(): void;
-  resetMatchData(): void;
 
   // Health
   getHealth(participant: Participant): Health;
 
-  // Optional setters for testing or future expansion
-  resetScores(): void;
+  // Reset all match data
+  resetGame(): void;
 }

--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -455,72 +455,58 @@ describe("Model", () => {
   });
 
   describe("Reset", () => {
-    test("resetScores should set both player and computer scores to 0", () => {
+    test("resetGame should completely wipe all game state, scores, and restore match defaults", () => {
+      // 1. Arrange: Populate the model and localStorage with dirty session data
       model.setPlayerScore(3);
       model.setComputerScore(2);
-      model.resetScores();
-      expect(model.getPlayerScore()).toBe(0);
-      expect(model.getComputerScore()).toBe(0);
-    });
-
-    test("resetTaras should set both player and computer Tara counts to 0", () => {
       model.setPlayerTaraCount(2);
       model.setComputerTaraCount(4);
-      model.resetTaras();
-      expect(model.getPlayerTaraCount()).toBe(0);
-      expect(model.getComputerTaraCount()).toBe(0);
-    });
 
-    test("resetMostCommonMoves removes most common moves from localStorage", () => {
       localStorage.setItem("playerMostCommonMove", MOVES.ROCK);
       localStorage.setItem("computerMostCommonMove", MOVES.SCISSORS);
 
-      model.resetMostCommonMoves();
-
-      expect(localStorage.getItem("playerMostCommonMove")).toBeNull();
-      expect(localStorage.getItem("computerMostCommonMove")).toBeNull();
-    });
-
-    test("resetMostCommonMoves clears most common move from state", () => {
-      model.setPlayerMostCommonMove();
-      model.setComputerMostCommonMove();
-
-      model.resetMostCommonMoves();
-
-      expect(model.getPlayerMostCommonMove()).toBeNull();
-      expect(model.getComputerMostCommonMove()).toBeNull();
-    });
-
-    test("resetBothMoveCounts resets both participants' localStorage counts", () => {
-      const playerMoveCounts = {
-        rock: 1,
-        paper: 1,
-        scissors: 0,
-      };
-      const computerMoveCounts = {
-        rock: 1,
-        paper: 0,
-        scissors: 1,
-      };
-
+      // Seed move data to test the move counts wipe
       model.registerPlayerMove(MOVES.ROCK);
       model.registerPlayerMove(MOVES.PAPER);
       model.registerComputerMove(MOVES.SCISSORS);
       model.registerComputerMove(MOVES.ROCK);
 
-      const initialPlayerStorage = localStorage.getItem("playerMoveCounts");
-      const initialComputerStorage = localStorage.getItem("computerMoveCounts");
+      // Give them non-default match data
+      const dirtyMatch = {
+        matchRoundNumber: 4,
+        playerHealth: 30,
+        computerHealth: 50,
+      } as Match;
+      model.setMatch(dirtyMatch);
+      model.setMatchNumber(5);
 
-      expect(JSON.parse(initialPlayerStorage!)).toEqual(playerMoveCounts);
-      expect(JSON.parse(initialComputerStorage!)).toEqual(computerMoveCounts);
+      // 2. Act: Call the single public entry point
+      model.resetGame();
 
-      model.resetBothMoveCounts();
+      // 3. Assert: Verify scores and other metrics are wiped to 0 / null
+      expect(model.getPlayerScore()).toBe(0);
+      expect(model.getComputerScore()).toBe(0);
 
-      const playerStorage = localStorage.getItem("playerMoveCounts");
-      const computerStorage = localStorage.getItem("computerMoveCounts");
+      expect(model.getPlayerTaraCount()).toBe(0);
+      expect(model.getComputerTaraCount()).toBe(0);
 
-      expect(JSON.parse(playerStorage!)).toEqual(null);
-      expect(JSON.parse(computerStorage!)).toEqual(null);
+      expect(model.getPlayerMostCommonMove()).toBeNull();
+      expect(model.getComputerMostCommonMove()).toBeNull();
+
+      // Match number resets to default
+      expect(model.getMatchNumber()).toBe(DEFAULT_MATCH_NUMBER);
+
+      // Health values query from the current match state, reverting to 100
+      expect(model.getHealth(PARTICIPANTS.PLAYER)).toBe(INITIAL_HEALTH);
+      expect(model.getHealth(PARTICIPANTS.COMPUTER)).toBe(INITIAL_HEALTH);
+
+      // LocalStorage Cleanliness
+      expect(localStorage.getItem("playerMostCommonMove")).toBeNull();
+      expect(localStorage.getItem("computerMostCommonMove")).toBeNull();
+      expect(localStorage.getItem("playerMoveCounts")).toBeNull();
+      expect(localStorage.getItem("computerMoveCounts")).toBeNull();
+      expect(localStorage.getItem("globalMatchNumber")).toBeNull();
+      expect(localStorage.getItem("currentMatch")).toBeNull();
     });
   });
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -154,6 +154,14 @@ export class Model {
     return this.gameStorage.getMatch() !== null;
   }
 
+  resetGame(): void {
+    this.resetScores();
+    this.resetTaras();
+    this.resetMostCommonMoves();
+    this.resetMoveCounts();
+    this.resetMatchData();
+  }
+
   // ===== Score Methods =====
 
   private setScore(key: Participant, value: number): void {
@@ -170,6 +178,11 @@ export class Model {
     this.gameStorage.removeScore(key);
   }
 
+  private resetScores(): void {
+    this.resetScore(PARTICIPANTS.PLAYER);
+    this.resetScore(PARTICIPANTS.COMPUTER);
+  }
+
   setPlayerScore(score: number) {
     this.setScore(PARTICIPANTS.PLAYER, score);
   }
@@ -181,11 +194,6 @@ export class Model {
   }
   getComputerScore() {
     return this.getScore(PARTICIPANTS.COMPUTER);
-  }
-
-  resetScores(): void {
-    this.resetScore(PARTICIPANTS.PLAYER);
-    this.resetScore(PARTICIPANTS.COMPUTER);
   }
 
   // ===== Move Methods =====
@@ -222,6 +230,11 @@ export class Model {
   private resetMostCommonMove(key: Participant): void {
     this.state.mostCommonMove[key] = null;
     this.gameStorage.removeMostCommonMove(key);
+  }
+
+  private resetMostCommonMoves(): void {
+    this.resetMostCommonMove(PARTICIPANTS.PLAYER);
+    this.resetMostCommonMove(PARTICIPANTS.COMPUTER);
   }
 
   private setMostCommonMove(key: Participant, moveCounts: MoveCount): void {
@@ -283,11 +296,6 @@ export class Model {
     this.setMostCommonMove(PARTICIPANTS.COMPUTER, moveCounts);
   }
 
-  resetMostCommonMoves(): void {
-    this.resetMostCommonMove(PARTICIPANTS.PLAYER);
-    this.resetMostCommonMove(PARTICIPANTS.COMPUTER);
-  }
-
   getPlayerMostCommonMove(): StandardMove | null {
     return this.getMostCommonMove(PARTICIPANTS.PLAYER);
   }
@@ -302,18 +310,18 @@ export class Model {
     this.gameStorage.setMoveCounts(key, this.state.moveCounts[key]);
   }
 
-  private resetMoveCounts(key: Participant): void {
+  private resetMoveCount(key: Participant): void {
     this.state.moveCounts[key] = { rock: 0, paper: 0, scissors: 0 };
     this.gameStorage.removeMoveCounts(key);
   }
 
-  private getMoveCounts(key: Participant): MoveCount {
-    return this.state.moveCounts[key];
+  private resetMoveCounts(): void {
+    this.resetMoveCount(PARTICIPANTS.PLAYER);
+    this.resetMoveCount(PARTICIPANTS.COMPUTER);
   }
 
-  resetBothMoveCounts(): void {
-    this.resetMoveCounts(PARTICIPANTS.PLAYER);
-    this.resetMoveCounts(PARTICIPANTS.COMPUTER);
+  private getMoveCounts(key: Participant): MoveCount {
+    return this.state.moveCounts[key];
   }
 
   showMostCommonMove(): boolean {
@@ -392,15 +400,17 @@ export class Model {
     this.gameStorage.removeTaraCount(key);
   }
 
+  private resetTaras(): void {
+    this.resetTaraCount(PARTICIPANTS.PLAYER);
+    this.resetTaraCount(PARTICIPANTS.COMPUTER);
+  }
+
   setPlayerTaraCount(count: number): void {
     this.setTaraCount(PARTICIPANTS.PLAYER, count);
   }
+
   setComputerTaraCount(count: number): void {
     this.setTaraCount(PARTICIPANTS.COMPUTER, count);
-  }
-  resetTaras(): void {
-    this.resetTaraCount(PARTICIPANTS.PLAYER);
-    this.resetTaraCount(PARTICIPANTS.COMPUTER);
   }
 
   getPlayerTaraCount(): number {
@@ -447,7 +457,7 @@ export class Model {
     }
   }
 
-  resetMatchData(): void {
+  private resetMatchData(): void {
     this.state.currentMatch = null;
     this.gameStorage.setMatch(null);
     this.setMatchNumber(null);


### PR DESCRIPTION
**Context**
Previously, the Controller was behaving as a micromanager during the game reset phase—manually invoking six individual reset endpoints to clear scores, historical records, and storage states. This leaked domain implementation details into the routing layer.

**What This PR Does**
- **Model Encapsulation:** Grouped internal cleanup tasks into a singular public method: `model.resetGame()`. Made granular sub-reset helper methods private.
- **Controller Simplification:** Reduced overhead inside `Controller.resetGameState()`, passing sole responsibility for data wiping back to the Model where it belongs.
- **Test Architecture Update:** Migrated brittle, implementation-tied unit tests in `model.test.ts` and `controller.test.ts` into a resilient integration test that asserts against post-reset data baselines rather than spy-tracking private method execution.

**Testing Status**
- ✅ Manual browser testing passed (Game resets completely and UI elements toggle/clear correctly).
- ✅ Unit/Integration tests updated and passing successfully (npm run test).