### PR TITLE
RPST-88: Fix: Restore tie animation sequence in arena view

### DIFF
--- a/src/views/arena/ArenaView.test.ts
+++ b/src/views/arena/ArenaView.test.ts
@@ -125,4 +125,58 @@ describe("ArenaView", () => {
       expect(content).toContain("❓"); // The fallback we discussed earlier
     });
   });
+
+  describe("Tie Animation Regression", () => {
+    it("should apply tie animation classes to both cards on tie", async () => {
+      const data = {
+        phase: "result" as const,
+        playerMoveId: "rock" as Move,
+        computerMoveId: "rock" as Move,
+        winner: "tie" as const,
+        isDoubleKO: false,
+        announcementMessage: "IT'S A TIE!",
+      };
+
+      await view.playRoundSequence(data);
+
+      const playerCard = document.getElementById("reveal-player");
+      const computerCard = document.getElementById("reveal-computer");
+      const container = document.getElementById("move-reveal");
+
+      // Both cards should have impact and defeated classes
+      expect(playerCard?.classList.contains("card-impact")).toBe(true);
+      expect(playerCard?.classList.contains("card-defeated")).toBe(true);
+      expect(computerCard?.classList.contains("card-impact")).toBe(true);
+      expect(computerCard?.classList.contains("card-defeated")).toBe(true);
+
+      // Container should shake
+      expect(container?.classList.contains("arena-shake")).toBe(true);
+    });
+
+    it("should apply double KO animation classes when isDoubleKO is true", async () => {
+      const data = {
+        phase: "result" as const,
+        playerMoveId: "rock" as Move,
+        computerMoveId: "paper" as Move,
+        winner: "player" as const, // winner doesn't matter for double KO
+        isDoubleKO: true,
+        announcementMessage: "MUTUAL DESTRUCTION!",
+      };
+
+      await view.playRoundSequence(data);
+
+      const playerCard = document.getElementById("reveal-player");
+      const computerCard = document.getElementById("reveal-computer");
+      const container = document.getElementById("move-reveal");
+
+      // Both cards should have impact and defeated classes
+      expect(playerCard?.classList.contains("card-impact")).toBe(true);
+      expect(playerCard?.classList.contains("card-defeated")).toBe(true);
+      expect(computerCard?.classList.contains("card-impact")).toBe(true);
+      expect(computerCard?.classList.contains("card-defeated")).toBe(true);
+
+      // Container should shake
+      expect(container?.classList.contains("arena-shake")).toBe(true);
+    });
+  });
 });

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -104,15 +104,15 @@ export default class ArenaView
 
     // 5. Outcome Drama
     this.update({ ...data, phase: "result" });
-    await this.executeOutcomeDrama(data, pCard, cCard, moveRevealContainer);
+    await this.executeOutcomeDrama(data);
   }
 
-  private async executeOutcomeDrama(
-    data: ArenaViewData,
-    pCard: HTMLElement,
-    cCard: HTMLElement,
-    container: HTMLElement,
-  ): Promise<void> {
+  private async executeOutcomeDrama(data: ArenaViewData): Promise<void> {
+    // Get fresh element references after DOM update
+    const pCard = this._getElement("reveal-player");
+    const cCard = this._getElement("reveal-computer");
+    const container = this._getElement("move-reveal");
+
     if (data.isDoubleKO || data.winner === "tie") {
       pCard.classList.add("card-impact", "card-defeated");
       cCard.classList.add("card-impact", "card-defeated");


### PR DESCRIPTION
**Problem**
Tie and double KO animations were not displaying during the result phase.

**Root Cause**
Element references captured before DOM updates were being reused after the DOM was regenerated with `innerHTML`, causing animation classes to be applied to detached nodes.

**Solution**
Refresh element references inside `executeOutcomeDrama()` after DOM update to target active elements.

**Changes**
- Fixed stale DOM reference bug in `ArenaView` animation sequence
- Added regression tests for tie and double KO animation scenarios