### PR TITLE
RPST-89: Encapsulate stats view render/update decision

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -111,8 +111,7 @@ describe("Controller", () => {
 
       expect(mockModel.handleMatchWin).toHaveBeenCalled();
 
-      // Since mockViews.statsView.hasData is false, it should call render instead of update
-      expect(mockViews.statsView.render).toHaveBeenCalled();
+      expect(mockViews.statsView.update).toHaveBeenCalled();
 
       expect(mockViews.controlsView.render).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -157,7 +156,7 @@ describe("Controller", () => {
       await controller.resetGameState();
 
       expect(mockModel.resetGame).toHaveBeenCalled();
-      expect(mockViews.statsView.render).toHaveBeenCalled();
+      expect(mockViews.statsView.update).toHaveBeenCalled();
       expect(mockViews.arenaView.clear).toHaveBeenCalled();
       expect(mockViews.controlsView.toggleVisibility).toHaveBeenCalledWith(
         false,

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -64,11 +64,7 @@ export class Controller {
       roundNumber: this.model.getRoundNumber(),
     };
 
-    if (!this.statsView.hasData) {
-      this.statsView.render(data);
-    } else {
-      this.statsView.update(data);
-    }
+    this.statsView.update(data);
   }
 
   private async startGame(): Promise<void> {

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -14,8 +14,6 @@ export interface StatsViewData {
 }
 
 export interface IStatsView {
-  render(data: StatsViewData): void;
   update(data: StatsViewData): void;
-  readonly hasData: boolean;
   toggleGameStatsVisibility(show: boolean): void;
 }

--- a/src/views/stats/StatsView.test.ts
+++ b/src/views/stats/StatsView.test.ts
@@ -32,8 +32,8 @@ describe("StatsView", () => {
 
   describe("toggleGameStatsVisibility()", () => {
     test("adds or removes the hidden class on the main stats container", () => {
-      // Must render first so the parent element is cached
-      view.render(defaultData);
+      // Must update first so the parent element is cached
+      view.update(defaultData);
       const statsContainer = document.getElementById("game-stats")!;
 
       view.toggleGameStatsVisibility(false);
@@ -44,9 +44,9 @@ describe("StatsView", () => {
     });
   });
 
-  describe("render()", () => {
-    test("generates and injects the full markup based on state", () => {
-      view.render(defaultData);
+  describe("update()", () => {
+    test("generates and injects the full markup on first call (initial render)", () => {
+      view.update(defaultData);
 
       expect(document.getElementById("player-health")!.style.width).toBe(
         "100%",
@@ -64,24 +64,20 @@ describe("StatsView", () => {
     });
 
     test("formats null common moves as '–'", () => {
-      view.render(defaultData);
+      view.update(defaultData);
       // Fix: target the last span
       expect(
         document.querySelector("#player-stats small span:last-child")!
           .textContent,
       ).toBe("–");
     });
-  });
 
-  describe("update()", () => {
-    beforeEach(() => {
-      // Render initial state to set up DOM for diffing
-      view.render(defaultData);
-    });
-
-    test("updates health bar width attributes without replacing elements", () => {
+    test("updates health bar width attributes without replacing elements (diff on subsequent calls)", () => {
+      // First call does initial render
+      view.update(defaultData);
       const oldPlayerHealthBar = document.getElementById("player-health")!;
 
+      // Second call uses diff update
       const newData = { ...defaultData, playerHealth: 45, computerHealth: 12 };
       view.update(newData);
 
@@ -97,6 +93,10 @@ describe("StatsView", () => {
     });
 
     test("updates scores and pads them correctly", () => {
+      // First call does initial render
+      view.update(defaultData);
+
+      // Second call uses diff update
       const newData = { ...defaultData, playerScore: 5, computerScore: 12 };
       view.update(newData);
 
@@ -111,6 +111,10 @@ describe("StatsView", () => {
     });
 
     test("updates most common moves", () => {
+      // First call does initial render
+      view.update(defaultData);
+
+      // Second call uses diff update
       const newData = {
         ...defaultData,
         playerMostCommonMove: MOVES.ROCK,

--- a/src/views/stats/StatsView.ts
+++ b/src/views/stats/StatsView.ts
@@ -13,9 +13,14 @@ export default class StatsView
     }
   }
 
-  public render(data: StatsViewData): void {
+  public update(data: StatsViewData): void {
     this._ensureParentElement();
-    super.render(data);
+
+    if (!this.hasData) {
+      super.render(data);
+    } else {
+      super.update(data);
+    }
   }
 
   public toggleGameStatsVisibility(show: boolean): void {


### PR DESCRIPTION
Simplifies the `StatsView` interface by exposing a single `update()` method that internally handles the render/update decision based on whether data has already been loaded.

**Changes:**
- Remove `render()` and `hasData` from I`StatsView` interface
- Override `update()` in `StatsView` to check `hasData` internally and call either full render or partial update
- Update controller to call `statsView.update()` without conditional logic
- Update tests to reflect the new interface

**Benefits:**
- Eliminates render/update decision logic from the controller
- Improves view encapsulation by keeping internal state decisions private
- Reduces coupling between controller and view implementation details