### PR TITLE
RPST-91 Improve health update timing during round animations

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -170,20 +170,21 @@ export class Controller {
       `You played ${MOVE_DISPLAY_NAMES[move]}. Computer played ${MOVE_DISPLAY_NAMES[computerMove]}.`,
     );
 
-    await this.arenaView.playRoundSequence({
-      phase: "waiting",
-      playerMoveId: move,
-      computerMoveId: computerMove,
-      winner: roundResult.winner,
-      isDoubleKO: roundResult.isDoubleKO,
-      announcementMessage: roundResult.isDoubleKO
-        ? "MUTUAL DESTRUCTION!"
-        : roundResult.winner !== "tie"
-          ? `${roundResult.winner.toUpperCase()} LANDS A BLOW!`
-          : "IT'S A TIE!",
-    });
-
-    this.updateStatsView();
+    await this.arenaView.playRoundSequence(
+      {
+        phase: "waiting",
+        playerMoveId: move,
+        computerMoveId: computerMove,
+        winner: roundResult.winner,
+        isDoubleKO: roundResult.isDoubleKO,
+        announcementMessage: roundResult.isDoubleKO
+          ? "MUTUAL DESTRUCTION!"
+          : roundResult.winner !== "tie"
+            ? `${roundResult.winner.toUpperCase()} LANDS A BLOW!`
+            : "IT'S A TIE!",
+      },
+      () => this.updateStatsView(),
+    );
     this.endRound();
   }
 

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -76,7 +76,10 @@ export default class ArenaView
     `;
   }
 
-  public async playRoundSequence(data: ArenaViewData): Promise<void> {
+  public async playRoundSequence(
+    data: ArenaViewData,
+    onOutcomeStart?: () => void,
+  ): Promise<void> {
     // 1. Render initial hidden cards
     this.render({ ...data, phase: "revealing", announcementMessage: "" });
     this._toggleVisibility(this._parentElement, true);
@@ -130,6 +133,8 @@ export default class ArenaView
 
     // 5. Outcome Drama
     this.update({ ...data, phase: "result" });
+    // Trigger health update the moment the blow lands
+    onOutcomeStart?.();
     await this.executeOutcomeDrama(data);
   }
 

--- a/src/views/arena/IArenaView.ts
+++ b/src/views/arena/IArenaView.ts
@@ -14,6 +14,9 @@ export interface ArenaViewData {
 export interface IArenaView {
   render(data: ArenaViewData): void;
   update(data: ArenaViewData): void;
-  playRoundSequence(data: ArenaViewData): Promise<void>;
+  playRoundSequence(
+    data: ArenaViewData,
+    onOutcomeStart?: () => void,
+  ): Promise<void>;
   clear(): void;
 }


### PR DESCRIPTION
Health stats now update immediately when a blow lands visually, rather than waiting for the entire animation sequence to complete. This provides instant feedback to players while maintaining the full animation and auto-advance delay.

**Changes:**
- Added optional `onOutcomeStart` callback to `IArenaView.playRoundSequence()`
- Trigger health update in `ArenaView` when outcome drama begins
- Pass callback from Controller to update stats at the moment of impact