### PR TITLE
RPST-92: Refactor: Decouple UI text from Controller via i18n and Semantic Events

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -62,6 +62,9 @@ describe("Controller", () => {
         clear: jest.fn(),
         playRoundSequence: jest.fn(),
         update: jest.fn(),
+        setAnnouncement: jest.fn(),
+        playRoundResult: jest.fn(),
+        playMatchResult: jest.fn(),
       } as any,
       controlsView: {
         render: jest.fn(),
@@ -84,7 +87,12 @@ describe("Controller", () => {
         update: jest.fn(),
         toggleGameStatsVisibility: jest.fn(),
       } as any,
-      statusView: { render: jest.fn(), setMessage: jest.fn() } as any,
+      statusView: {
+        render: jest.fn(),
+        setMessage: jest.fn(),
+        handleEvent: jest.fn(),
+        announceRound: jest.fn(),
+      } as any,
     };
 
     controller = new Controller(mockModel, mockViews);
@@ -107,7 +115,7 @@ describe("Controller", () => {
       mockModel.handleMatchWin.mockReturnValue("player");
 
       // @ts-ignore
-      controller.endRound("player wins round");
+      controller.endRound();
 
       expect(mockModel.handleMatchWin).toHaveBeenCalled();
 
@@ -126,7 +134,7 @@ describe("Controller", () => {
       mockModel.isMatchOver.mockReturnValue(false);
 
       // @ts-ignore
-      controller.endRound("draw");
+      controller.endRound();
 
       expect(mockModel.increaseRoundNumber).toHaveBeenCalled();
 

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -102,8 +102,6 @@ export class Controller {
 
     // --- ROUND CONTINUES ---
     this.model.increaseRoundNumber();
-
-    // It's safe to update full stats here because we want the user to see the new round number
     this.updateStatsView();
 
     setTimeout(() => {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -72,7 +72,7 @@ export class Controller {
     this.updateStatsView();
 
     this.resetArenaVisuals();
-    this.statusView.setMessage("Get ready...");
+    this.statusView.handleEvent({ type: "READY" });
 
     this.menuView.toggleMenuVisibility(false);
     this.gameView.toggleVisibility(true);
@@ -82,28 +82,15 @@ export class Controller {
     await this.handleNextRound();
   }
 
-  private endRound(): void {
-    const matchActuallyEnded = this.model.isMatchOver();
+  private async endRound(): Promise<void> {
+    const matchOver = this.model.isMatchOver();
     const isDoubleKO = this.model.isDoubleKO();
 
-    this.updateStatsView();
-
     // --- MATCH END ---
-    if (matchActuallyEnded) {
+    if (matchOver) {
       const result = this.model.handleMatchWin();
 
-      const resultMessage = isDoubleKO
-        ? "DOUBLE KO! NOBODY WINS!"
-        : `${result.toUpperCase()} WON THE MATCH!`;
-
-      // Update the arena view to show the final match message, keeping cards visible
-      this.arenaView.update({
-        phase: "result",
-        playerMoveId: this.model.getPlayerMove(),
-        computerMoveId: this.model.getComputerMove(),
-        announcementMessage: resultMessage,
-        winner: result as Participant,
-      });
+      this.arenaView.playMatchResult(result as Participant, isDoubleKO);
 
       this.updateStatsView();
       this.updateControlsView();
@@ -114,16 +101,18 @@ export class Controller {
     }
 
     // --- ROUND CONTINUES ---
-    this.updateStatsView();
     this.model.increaseRoundNumber();
+
+    // It's safe to update full stats here because we want the user to see the new round number
+    this.updateStatsView();
 
     setTimeout(() => {
       this.handleNextRound();
-    }, 2000);
+    }, 250);
   }
 
   private async handleNextRound(): Promise<void> {
-    this.statusView.setMessage("Prepare your next move...");
+    this.statusView.handleEvent({ type: "PREPARE" });
 
     this.model.resetMoves();
 
@@ -132,7 +121,7 @@ export class Controller {
     this.updateStatsView();
 
     await this.controlsView.flipAll(true);
-    this.statusView.setMessage("Choose your attack!");
+    this.statusView.handleEvent({ type: "CHOOSE" });
   }
 
   async resetGameState(): Promise<void> {
@@ -152,24 +141,22 @@ export class Controller {
   }
 
   async handlePlayerMove(move: Move): Promise<void> {
-    this.statusView.setMessage("Locking in move...");
+    this.statusView.handleEvent({ type: "LOCK_IN" });
     await this.controlsView.flipAll(false);
 
-    // 1. Get the computer's move purely based on historical state
     const computerMove = this.model.getCalculatedComputerMove();
-
-    // 2. Explicitly commit both moves to state (this triggers the metric counters)
     this.model.registerPlayerMove(move);
     this.model.registerComputerMove(computerMove);
 
-    // 3. Evaluate the rules deterministically
     const roundResult = this.model.evaluateRound();
 
-    // 4. Update UI using the plain variables we have right here
-    this.statusView.setMessage(
-      `You played ${MOVE_DISPLAY_NAMES[move]}. Computer played ${MOVE_DISPLAY_NAMES[computerMove]}.`,
+    // 1. Status bar updates: "You played X. Computer played Y."
+    this.statusView.announceRound(
+      MOVE_DISPLAY_NAMES[move],
+      MOVE_DISPLAY_NAMES[computerMove],
     );
 
+    // 2. Play the visual sequence
     await this.arenaView.playRoundSequence(
       {
         phase: "waiting",
@@ -177,15 +164,23 @@ export class Controller {
         computerMoveId: computerMove,
         winner: roundResult.winner,
         isDoubleKO: roundResult.isDoubleKO,
-        announcementMessage: roundResult.isDoubleKO
-          ? "MUTUAL DESTRUCTION!"
-          : roundResult.winner !== "tie"
-            ? `${roundResult.winner.toUpperCase()} LANDS A BLOW!`
-            : "IT'S A TIE!",
       },
-      () => this.updateStatsView(),
+      () => {
+        // 💥 IMPACT FRAME 💥
+
+        // Smoothly drop health bars
+        this.statsView.updateHealth(
+          this.model.getHealth(PARTICIPANTS.PLAYER) ?? 100,
+          this.model.getHealth(PARTICIPANTS.COMPUTER) ?? 100,
+        );
+
+        // Flash the round outcome text (e.g., "PLAYER LANDS A BLOW!")
+        this.arenaView.playRoundResult(roundResult);
+      },
     );
-    this.endRound();
+
+    // 3. Resolve the round once all drama and delays are finished
+    await this.endRound();
   }
 
   async initialize(): Promise<void> {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,12 +1,12 @@
 {
-  "status_ready": "Get ready...",
+  "arena_doubleKo": "MUTUAL DESTRUCTION!",
+  "arena_matchDoubleKo": "DOUBLE KO! NOBODY WINS!",
+  "arena_matchWinner": "{{winner}} WON THE MATCH!",
+  "arena_roundWin": "{{winner}} LANDS A BLOW!",
+  "arena_tie": "IT'S A TIE!",
+  "status_choose": "Choose your attack!",
   "status_lockIn": "Locking in move...",
   "status_prepare": "Prepare your next move...",
-  "status_choose": "Choose your attack!",
-  "status_roundResult": "You played {{playerMove}}. Computer played {{computerMove}}.",
-  "arena_doubleKo": "MUTUAL DESTRUCTION!",
-  "arena_playerWin": "{{winner}} LANDS A BLOW!",
-  "arena_tie": "IT'S A TIE!",
-  "arena_matchDoubleKo": "DOUBLE KO! NOBODY WINS!",
-  "arena_matchWinner": "{{winner}} WON THE MATCH!"
+  "status_ready": "Get ready...",
+  "status_roundResult": "You played {{playerMove}}. Computer played {{computerMove}}."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,12 @@
+{
+  "status_ready": "Get ready...",
+  "status_lockIn": "Locking in move...",
+  "status_prepare": "Prepare your next move...",
+  "status_choose": "Choose your attack!",
+  "status_roundResult": "You played {{playerMove}}. Computer played {{computerMove}}.",
+  "arena_doubleKo": "MUTUAL DESTRUCTION!",
+  "arena_playerWin": "{{winner}} LANDS A BLOW!",
+  "arena_tie": "IT'S A TIE!",
+  "arena_matchDoubleKo": "DOUBLE KO! NOBODY WINS!",
+  "arena_matchWinner": "{{winner}} WON THE MATCH!"
+}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,41 @@
+import enDictionary from "../locales/en.json";
+
+export type TranslationKey = keyof typeof enDictionary;
+
+/**
+ * Translates a key from the dictionary and optionally substitutes variables.
+ *
+ * ## Variable Substitution
+ * Variables in templates use double curly braces: `{{variableName}}`
+ *
+ * If a variable is provided in the `variables` map, it replaces the placeholder.
+ * If a variable is undefined, it falls back to showing the literal placeholder
+ * (e.g., `"{{unknownVar}"` remains in the output). This prevents broken UI when
+ * data is missing while making the gap obvious during development.
+ *
+ * @param key - The translation key from the dictionary
+ * @param variables - Optional record of variable names and their string/number values
+ * @returns The translated string with variables substituted
+ *
+ * @example
+ * t("status_ready") // "Get ready..."
+ * t("status_roundResult", { playerMove: "Rock", computerMove: "Paper" })
+ * // "You played Rock. Computer played Paper."
+ */
+export function t(
+  key: TranslationKey,
+  variables?: Record<string, string | number>,
+): string {
+  const template = enDictionary[key];
+
+  if (!variables) {
+    return template;
+  }
+
+  return template.replace(
+    /\{\{(\w+)\}\}/g,
+    (match: string, varName: string) => {
+      return String(variables[varName] ?? match);
+    },
+  );
+}

--- a/src/views/arena/ArenaView.interpretation.test.ts
+++ b/src/views/arena/ArenaView.interpretation.test.ts
@@ -32,7 +32,7 @@ describe("ArenaView Interpretation Logic", () => {
       expect(event.type).toBe("DOUBLE_KO");
     });
 
-    it("returns PLAYER_WIN event when player wins the round", () => {
+    it("returns ROUND_WIN event when player wins the round", () => {
       const roundResult: RoundResult = {
         winner: "player",
         isDoubleKO: false,
@@ -41,11 +41,11 @@ describe("ArenaView Interpretation Logic", () => {
 
       const event = (view as any).determineRoundAnnouncement(roundResult);
 
-      expect(event.type).toBe("PLAYER_WIN");
+      expect(event.type).toBe("ROUND_WIN");
       expect((event as any).payload.winner).toBe("player");
     });
 
-    it("returns PLAYER_WIN event when computer wins the round", () => {
+    it("returns ROUND_WIN event when computer wins the round", () => {
       const roundResult: RoundResult = {
         winner: "computer",
         isDoubleKO: false,
@@ -54,7 +54,7 @@ describe("ArenaView Interpretation Logic", () => {
 
       const event = (view as any).determineRoundAnnouncement(roundResult);
 
-      expect(event.type).toBe("PLAYER_WIN");
+      expect(event.type).toBe("ROUND_WIN");
       expect((event as any).payload.winner).toBe("computer");
     });
 
@@ -92,17 +92,17 @@ describe("ArenaView Interpretation Logic", () => {
       expect(event.type).toBe("MATCH_DOUBLE_KO");
     });
 
-    it("returns MATCH_WINNER with winner=player when player wins", () => {
+    it("returns MATCH_WIN with winner=player when player wins", () => {
       const event = (view as any).determineMatchAnnouncement("player", false);
 
-      expect(event.type).toBe("MATCH_WINNER");
+      expect(event.type).toBe("MATCH_WIN");
       expect((event as any).payload.winner).toBe("player");
     });
 
-    it("returns MATCH_WINNER with winner=computer when computer wins", () => {
+    it("returns MATCH_WIN with winner=computer when computer wins", () => {
       const event = (view as any).determineMatchAnnouncement("computer", false);
 
-      expect(event.type).toBe("MATCH_WINNER");
+      expect(event.type).toBe("MATCH_WIN");
       expect((event as any).payload.winner).toBe("computer");
     });
 
@@ -135,7 +135,7 @@ describe("ArenaView Interpretation Logic", () => {
       view.playRoundResult(roundResult);
 
       expect(setAnnouncementSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "PLAYER_WIN" }),
+        expect.objectContaining({ type: "ROUND_WIN" }),
       );
     });
 
@@ -146,7 +146,7 @@ describe("ArenaView Interpretation Logic", () => {
 
       expect(setAnnouncementSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: "MATCH_WINNER",
+          type: "MATCH_WIN",
           payload: { winner: "computer" },
         }),
       );

--- a/src/views/arena/ArenaView.interpretation.test.ts
+++ b/src/views/arena/ArenaView.interpretation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for ArenaView's interpretation logic (decision-making).
+ *
+ * This test file focuses on the private helper methods that interpret game state
+ * and decide which announcement events to emit. This demonstrates the
+ * "View owns UI interpretation" pattern and makes the decision logic testable.
+ */
+import ArenaView from "./ArenaView";
+import { RoundResult } from "../../utils/dataObjectUtils";
+
+describe("ArenaView Interpretation Logic", () => {
+  let view: ArenaView;
+
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="arena"></div>`;
+    view = new ArenaView();
+    (view as any)._waitForAnimation = jest.fn().mockResolvedValue(undefined);
+  });
+
+  describe("determineRoundAnnouncement", () => {
+    it("returns DOUBLE_KO event when both players take mutual damage", () => {
+      const roundResult: RoundResult = {
+        winner: "tie",
+        isDoubleKO: true,
+        damageCalculated: 25,
+      };
+
+      const event = (view as any).determineRoundAnnouncement(roundResult);
+
+      expect(event.type).toBe("DOUBLE_KO");
+    });
+
+    it("returns PLAYER_WIN event when player wins the round", () => {
+      const roundResult: RoundResult = {
+        winner: "player",
+        isDoubleKO: false,
+        damageCalculated: 30,
+      };
+
+      const event = (view as any).determineRoundAnnouncement(roundResult);
+
+      expect(event.type).toBe("PLAYER_WIN");
+      expect((event as any).payload.winner).toBe("player");
+    });
+
+    it("returns PLAYER_WIN event when computer wins the round", () => {
+      const roundResult: RoundResult = {
+        winner: "computer",
+        isDoubleKO: false,
+        damageCalculated: 30,
+      };
+
+      const event = (view as any).determineRoundAnnouncement(roundResult);
+
+      expect(event.type).toBe("PLAYER_WIN");
+      expect((event as any).payload.winner).toBe("computer");
+    });
+
+    it("returns TIE event when round is a tie (non-double-KO)", () => {
+      const roundResult: RoundResult = {
+        winner: "tie",
+        isDoubleKO: false,
+        damageCalculated: 0,
+      };
+
+      const event = (view as any).determineRoundAnnouncement(roundResult);
+
+      expect(event.type).toBe("TIE");
+    });
+
+    it("prioritizes DOUBLE_KO over TIE even if winner is tie", () => {
+      // Edge case: both double KO'd AND it's a tie
+      const roundResult: RoundResult = {
+        winner: "tie",
+        isDoubleKO: true,
+        damageCalculated: 25,
+      };
+
+      const event = (view as any).determineRoundAnnouncement(roundResult);
+
+      // Should emit DOUBLE_KO, not TIE
+      expect(event.type).toBe("DOUBLE_KO");
+    });
+  });
+
+  describe("determineMatchAnnouncement", () => {
+    it("returns MATCH_DOUBLE_KO when isDoubleKO is true", () => {
+      const event = (view as any).determineMatchAnnouncement("player", true);
+
+      expect(event.type).toBe("MATCH_DOUBLE_KO");
+    });
+
+    it("returns MATCH_WINNER with winner=player when player wins", () => {
+      const event = (view as any).determineMatchAnnouncement("player", false);
+
+      expect(event.type).toBe("MATCH_WINNER");
+      expect((event as any).payload.winner).toBe("player");
+    });
+
+    it("returns MATCH_WINNER with winner=computer when computer wins", () => {
+      const event = (view as any).determineMatchAnnouncement("computer", false);
+
+      expect(event.type).toBe("MATCH_WINNER");
+      expect((event as any).payload.winner).toBe("computer");
+    });
+
+    it("ignores winner parameter when isDoubleKO is true", () => {
+      // Even though player is passed, should emit MATCH_DOUBLE_KO
+      const event = (view as any).determineMatchAnnouncement("player", true);
+
+      expect(event.type).toBe("MATCH_DOUBLE_KO");
+      expect((event as any).payload).toBeUndefined();
+    });
+  });
+
+  /**
+   * Integration test: Verifies that public methods use the helper methods correctly
+   */
+  describe("Integration: Public methods call helpers", () => {
+    it("playRoundResult calls determineRoundAnnouncement and setAnnouncement", () => {
+      const setAnnouncementSpy = jest.spyOn(view, "setAnnouncement");
+
+      const roundResult: RoundResult = {
+        winner: "player",
+        isDoubleKO: false,
+        damageCalculated: 30,
+      };
+
+      view.playRoundResult(roundResult);
+
+      expect(setAnnouncementSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "PLAYER_WIN" }),
+      );
+    });
+
+    it("playMatchResult calls determineMatchAnnouncement and setAnnouncement", () => {
+      const setAnnouncementSpy = jest.spyOn(view, "setAnnouncement");
+
+      view.playMatchResult("computer", false);
+
+      expect(setAnnouncementSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "MATCH_WINNER",
+          payload: { winner: "computer" },
+        }),
+      );
+    });
+  });
+});

--- a/src/views/arena/ArenaView.interpretation.test.ts
+++ b/src/views/arena/ArenaView.interpretation.test.ts
@@ -119,6 +119,10 @@ describe("ArenaView Interpretation Logic", () => {
    * Integration test: Verifies that public methods use the helper methods correctly
    */
   describe("Integration: Public methods call helpers", () => {
+    beforeEach(() => {
+      view.render({ phase: "result" });
+    });
+
     it("playRoundResult calls determineRoundAnnouncement and setAnnouncement", () => {
       const setAnnouncementSpy = jest.spyOn(view, "setAnnouncement");
 

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -178,7 +178,7 @@ export default class ArenaView
    *
    * Decision logic:
    * 1. If both took mutual damage (double KO) → DOUBLE_KO event
-   * 2. If there's a winner → PLAYER_WIN with winner name
+   * 2. If there's a winner → ROUND_WIN with winner name
    * 3. If neither won → TIE event
    *
    * This demonstrates the data-driven pattern: the view receives semantic game state
@@ -213,7 +213,10 @@ export default class ArenaView
     }
 
     if (roundResult.winner !== "tie") {
-      return { type: "PLAYER_WIN", payload: { winner: roundResult.winner } };
+      return {
+        type: "ROUND_WIN",
+        payload: { winner: roundResult.winner },
+      };
     }
 
     return { type: "TIE" };
@@ -229,7 +232,7 @@ export default class ArenaView
   ): ArenaAnnouncementEvent {
     return isDoubleKO
       ? { type: "MATCH_DOUBLE_KO" }
-      : { type: "MATCH_WINNER", payload: { winner } };
+      : { type: "MATCH_WIN", payload: { winner } };
   }
 
   public setAnnouncement(event: ArenaAnnouncementEvent): void {
@@ -239,8 +242,8 @@ export default class ArenaView
       case "DOUBLE_KO":
         announcementMessage = t("arena_doubleKo");
         break;
-      case "PLAYER_WIN":
-        announcementMessage = t("arena_playerWin", {
+      case "ROUND_WIN":
+        announcementMessage = t("arena_roundWin", {
           winner: event.payload.winner.toUpperCase(),
         });
         break;
@@ -250,7 +253,7 @@ export default class ArenaView
       case "MATCH_DOUBLE_KO":
         announcementMessage = t("arena_matchDoubleKo");
         break;
-      case "MATCH_WINNER":
+      case "MATCH_WIN":
         announcementMessage = t("arena_matchWinner", {
           winner: event.payload.winner.toUpperCase(),
         });

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -266,12 +266,8 @@ export default class ArenaView
     this._data = { ...this._data, announcementMessage };
 
     // Update only the announcement container to preserve animation classes on cards
-    const announcementContainer = this._parentElement.querySelector(
-      "#announcement-container",
-    );
-    if (announcementContainer) {
-      announcementContainer.innerHTML = `<h2>${announcementMessage}</h2>`;
-    }
+    const announcementContainer = this._getElement("announcement-container");
+    announcementContainer.innerHTML = `<h2>${announcementMessage}</h2>`;
   }
 
   public update(data: ArenaViewData): void {
@@ -287,17 +283,15 @@ export default class ArenaView
   private applyWinnerStyles(winner: Participant | "tie"): void {
     if (winner === "tie") return;
 
-    const pCard = document.getElementById("reveal-player");
-    const cCard = document.getElementById("reveal-computer");
-
-    if (!pCard || !cCard) return;
+    const playerCard = this._getElement("reveal-player");
+    const computerCard = this._getElement("reveal-computer");
 
     if (winner === "player") {
-      pCard.classList.add("winner-highlight");
-      cCard.classList.add("card-defeated");
+      playerCard.classList.add("winner-highlight");
+      computerCard.classList.add("card-defeated");
     } else if (winner === "computer") {
-      cCard.classList.add("winner-highlight");
-      pCard.classList.add("card-defeated");
+      computerCard.classList.add("winner-highlight");
+      playerCard.classList.add("card-defeated");
     }
   }
 }

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -1,8 +1,13 @@
 // ArenaView.ts
 import View from "../View";
-import { IArenaView, ArenaViewData } from "./IArenaView";
+import {
+  IArenaView,
+  ArenaViewData,
+  ArenaAnnouncementEvent,
+} from "./IArenaView";
 import { PLAYER_MOVES_DATA, PARTICIPANTS } from "../../utils/dataUtils";
-import { Participant } from "../../utils/dataObjectUtils";
+import { Participant, RoundResult } from "../../utils/dataObjectUtils";
+import { t } from "../../utils/i18n";
 
 export default class ArenaView
   extends View<ArenaViewData>
@@ -166,6 +171,107 @@ export default class ArenaView
 
   public clear(): void {
     this.render({ phase: "waiting" });
+  }
+
+  /**
+   * Interprets round outcome and emits the corresponding announcement.
+   *
+   * Decision logic:
+   * 1. If both took mutual damage (double KO) → DOUBLE_KO event
+   * 2. If there's a winner → PLAYER_WIN with winner name
+   * 3. If neither won → TIE event
+   *
+   * This demonstrates the data-driven pattern: the view receives semantic game state
+   * and decides what UI event to emit, rather than the controller deciding.
+   */
+  public playRoundResult(roundResult: RoundResult): void {
+    const event = this.determineRoundAnnouncement(roundResult);
+    this.setAnnouncement(event);
+  }
+
+  /**
+   * Interprets match outcome, manages the cinematic delay, and emits the announcement.
+   */
+  public playMatchResult(winner: Participant, isDoubleKO: boolean): void {
+    // 1. Announce the match winner
+    const event = this.determineMatchAnnouncement(winner, isDoubleKO);
+    this.setAnnouncement(event);
+
+    // 2. Re-enforce the winner styles (in case of a tie-breaker or double KO context)
+    this.applyWinnerStyles(winner);
+  }
+
+  /**
+   * Helper: Determines which round announcement event to emit based on game state.
+   * @private
+   */
+  private determineRoundAnnouncement(
+    roundResult: RoundResult,
+  ): ArenaAnnouncementEvent {
+    if (roundResult.isDoubleKO) {
+      return { type: "DOUBLE_KO" };
+    }
+
+    if (roundResult.winner !== "tie") {
+      return { type: "PLAYER_WIN", payload: { winner: roundResult.winner } };
+    }
+
+    return { type: "TIE" };
+  }
+
+  /**
+   * Helper: Determines which match announcement event to emit based on game outcome.
+   * @private
+   */
+  private determineMatchAnnouncement(
+    winner: Participant,
+    isDoubleKO: boolean,
+  ): ArenaAnnouncementEvent {
+    return isDoubleKO
+      ? { type: "MATCH_DOUBLE_KO" }
+      : { type: "MATCH_WINNER", payload: { winner } };
+  }
+
+  public setAnnouncement(event: ArenaAnnouncementEvent): void {
+    let announcementMessage: string;
+
+    switch (event.type) {
+      case "DOUBLE_KO":
+        announcementMessage = t("arena_doubleKo");
+        break;
+      case "PLAYER_WIN":
+        announcementMessage = t("arena_playerWin", {
+          winner: event.payload.winner.toUpperCase(),
+        });
+        break;
+      case "TIE":
+        announcementMessage = t("arena_tie");
+        break;
+      case "MATCH_DOUBLE_KO":
+        announcementMessage = t("arena_matchDoubleKo");
+        break;
+      case "MATCH_WINNER":
+        announcementMessage = t("arena_matchWinner", {
+          winner: event.payload.winner.toUpperCase(),
+        });
+        break;
+      case "CUSTOM":
+        announcementMessage = event.message;
+        break;
+      default:
+        const _exhaustive: never = event;
+        throw new Error(`Unhandled event type: ${_exhaustive}`);
+    }
+
+    this._data = { ...this._data, announcementMessage };
+
+    // Update only the announcement container to preserve animation classes on cards
+    const announcementContainer = this._parentElement.querySelector(
+      "#announcement-container",
+    );
+    if (announcementContainer) {
+      announcementContainer.innerHTML = `<h2>${announcementMessage}</h2>`;
+    }
   }
 
   public update(data: ArenaViewData): void {

--- a/src/views/arena/IArenaView.ts
+++ b/src/views/arena/IArenaView.ts
@@ -11,10 +11,10 @@ export type ArenaPhase = "waiting" | "revealing" | "combat" | "result";
  */
 export type ArenaAnnouncementEvent =
   | { type: "DOUBLE_KO" }
-  | { type: "PLAYER_WIN"; payload: { winner: Participant } }
+  | { type: "ROUND_WIN"; payload: { winner: Participant } }
   | { type: "TIE" }
   | { type: "MATCH_DOUBLE_KO" }
-  | { type: "MATCH_WINNER"; payload: { winner: Participant } }
+  | { type: "MATCH_WIN"; payload: { winner: Participant } }
   | { type: "CUSTOM"; message: string };
 
 export interface ArenaViewData {

--- a/src/views/arena/IArenaView.ts
+++ b/src/views/arena/IArenaView.ts
@@ -1,6 +1,21 @@
-import { Move, Participant } from "../../utils/dataObjectUtils";
+import { Move, Participant, RoundResult } from "../../utils/dataObjectUtils";
 
 export type ArenaPhase = "waiting" | "revealing" | "combat" | "result";
+
+/**
+ * Semantic announcement events interpreted and emitted by the Arena View.
+ *
+ * The Arena View owns the decision logic for converting game state (RoundResult, match outcome)
+ * into these semantic events. This keeps the Controller focused on orchestration rather than
+ * UI interpretation logic.
+ */
+export type ArenaAnnouncementEvent =
+  | { type: "DOUBLE_KO" }
+  | { type: "PLAYER_WIN"; payload: { winner: Participant } }
+  | { type: "TIE" }
+  | { type: "MATCH_DOUBLE_KO" }
+  | { type: "MATCH_WINNER"; payload: { winner: Participant } }
+  | { type: "CUSTOM"; message: string };
 
 export interface ArenaViewData {
   phase: ArenaPhase;
@@ -11,12 +26,34 @@ export interface ArenaViewData {
   announcementMessage?: string;
 }
 
+/**
+ * Arena View handles both the visual combat sequence and semantic interpretation of game results.
+ */
 export interface IArenaView {
   render(data: ArenaViewData): void;
   update(data: ArenaViewData): void;
+  /**
+   * Plays the full round animation sequence (card entrance, flip, stance, outcome).
+   * The view does NOT handle announcements here—use `playRoundResult()` after this completes.
+   */
   playRoundSequence(
     data: ArenaViewData,
     onOutcomeStart?: () => void,
   ): Promise<void>;
   clear(): void;
+  setAnnouncement(event: ArenaAnnouncementEvent): void;
+  /**
+   * Interprets round outcome and announces it.
+   * The view decides: is this a double KO, a win, or a tie?
+   * @param roundResult - Game state containing winner and isDoubleKO
+   */
+  playRoundResult(roundResult: RoundResult): void;
+  /**
+/**
+   * Interprets match outcome, announces it, and manages the visual timing.
+   * Returns a Promise so the Controller can delay final stat/control updates.
+   * @param winner - The match winner (player or computer)
+   * @param isDoubleKO - Whether both participants were double KO'd
+   */
+  playMatchResult(winner: Participant, isDoubleKO: boolean): void;
 }

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -15,5 +15,6 @@ export interface StatsViewData {
 
 export interface IStatsView {
   update(data: StatsViewData): void;
+  updateHealth(playerHealth: number, computerHealth: number): void;
   toggleGameStatsVisibility(show: boolean): void;
 }

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -1,4 +1,4 @@
-import { Health, Move, Participant } from "../../utils/dataObjectUtils";
+import { Health, Move } from "../../utils/dataObjectUtils";
 
 export interface StatsViewData {
   playerHealth: Health;

--- a/src/views/stats/StatsView.ts
+++ b/src/views/stats/StatsView.ts
@@ -28,6 +28,27 @@ export default class StatsView
     this._toggleVisibility(this._parentElement, show);
   }
 
+  /**
+   * Performs a targeted DOM update specifically for health bars.
+   * This preserves CSS transitions by preventing a full innerHTML wipe,
+   * and allows health to drop instantly at impact without spoiling match scores.
+   */
+  public updateHealth(playerHealth: number, computerHealth: number): void {
+    const playerBar = this._parentElement?.querySelector(
+      "#player-health",
+    ) as HTMLElement;
+    const computerBar = this._parentElement?.querySelector(
+      "#computer-health",
+    ) as HTMLElement;
+
+    if (playerBar) playerBar.style.width = `${playerHealth}%`;
+    if (computerBar) computerBar.style.width = `${computerHealth}%`;
+
+    // Keep internal data model in sync so subsequent full renders don't revert the health
+    this._data.playerHealth = playerHealth;
+    this._data.computerHealth = computerHealth;
+  }
+
   protected _generateMarkup(): string {
     const {
       playerHealth,

--- a/src/views/status/IStatusView.ts
+++ b/src/views/status/IStatusView.ts
@@ -1,8 +1,37 @@
+/**
+ * Semantic events that Status View interprets and translates to localized messages.
+ * The view owns the logic for converting these events to UI text.
+ */
+export type StatusViewEvent =
+  | { type: "READY" }
+  | { type: "LOCK_IN" }
+  | { type: "PREPARE" }
+  | { type: "CHOOSE" }
+  | { type: "CUSTOM"; message: string };
+
 export interface StatusViewData {
   message: string;
 }
 
+/**
+ * Status View displays game state messages (status bar text).
+ *
+ * ## Data-Driven Announcements
+ *
+ * The `announceRound()` method demonstrates the data-driven pattern:
+ * the Controller passes raw move names, and the View translates them
+ * to a localized announcement message. This keeps the Controller focused
+ * on game logic rather than UI text.
+ */
 export interface IStatusView {
   render(data: StatusViewData): void;
   setMessage(message: string): void;
+  handleEvent(event: StatusViewEvent): void;
+  /**
+   * Announces the result of a round by translating move names to a localized message.
+   * The view handles all text formatting and i18n concerns.
+   * @param playerMove - The player's move display name (e.g., "Rock", "Paper")
+   * @param computerMove - The computer's move display name
+   */
+  announceRound(playerMove: string, computerMove: string): void;
 }

--- a/src/views/status/IStatusView.ts
+++ b/src/views/status/IStatusView.ts
@@ -15,13 +15,6 @@ export interface StatusViewData {
 
 /**
  * Status View displays game state messages (status bar text).
- *
- * ## Data-Driven Announcements
- *
- * The `announceRound()` method demonstrates the data-driven pattern:
- * the Controller passes raw move names, and the View translates them
- * to a localized announcement message. This keeps the Controller focused
- * on game logic rather than UI text.
  */
 export interface IStatusView {
   render(data: StatusViewData): void;

--- a/src/views/status/StatusView.interpretation.test.ts
+++ b/src/views/status/StatusView.interpretation.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for StatusView's interpretation logic (event translation).
+ *
+ * This test file focuses on the private helper method that interprets semantic events
+ * and translates them to localized messages. This demonstrates how Views handle
+ * UI text translation and makes the logic testable.
+ */
+import StatusView from "./StatusView";
+import { StatusViewEvent } from "./IStatusView";
+
+describe("StatusView Interpretation Logic", () => {
+  let view: StatusView;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="status-container"></div>
+    `;
+    view = new StatusView();
+    view.render({ message: "" });
+  });
+
+  describe("translateEvent", () => {
+    it("translates READY event to status_ready message", () => {
+      const message = (view as any).translateEvent({ type: "READY" });
+
+      expect(message).toBe("Get ready...");
+    });
+
+    it("translates LOCK_IN event to status_lockIn message", () => {
+      const message = (view as any).translateEvent({ type: "LOCK_IN" });
+
+      expect(message).toBe("Locking in move...");
+    });
+
+    it("translates PREPARE event to status_prepare message", () => {
+      const message = (view as any).translateEvent({ type: "PREPARE" });
+
+      expect(message).toBe("Prepare your next move...");
+    });
+
+    it("translates CHOOSE event to status_choose message", () => {
+      const message = (view as any).translateEvent({ type: "CHOOSE" });
+
+      expect(message).toBe("Choose your attack!");
+    });
+
+    it("returns raw message for CUSTOM event without translation", () => {
+      const customMessage = "This is a custom message";
+      const event: StatusViewEvent = {
+        type: "CUSTOM",
+        message: customMessage,
+      };
+
+      const message = (view as any).translateEvent(event);
+
+      expect(message).toBe(customMessage);
+    });
+
+    it("throws error for unknown event type (exhaustiveness check)", () => {
+      const unknownEvent = { type: "UNKNOWN" };
+
+      expect(() => {
+        (view as any).translateEvent(unknownEvent);
+      }).toThrow("Unhandled event type");
+    });
+  });
+
+  describe("Integration: handleEvent uses translateEvent", () => {
+    it("handleEvent translates event and updates message", () => {
+      const setMessageSpy = jest.spyOn(view, "setMessage");
+
+      view.handleEvent({ type: "READY" });
+
+      expect(setMessageSpy).toHaveBeenCalledWith("Get ready...");
+    });
+
+    it("handleEvent uses translator for all event types", () => {
+      const events: StatusViewEvent[] = [
+        { type: "READY" },
+        { type: "LOCK_IN" },
+        { type: "PREPARE" },
+        { type: "CHOOSE" },
+        { type: "CUSTOM", message: "Test" },
+      ];
+
+      for (const event of events) {
+        expect(() => view.handleEvent(event)).not.toThrow();
+      }
+    });
+  });
+
+  describe("announceRound", () => {
+    it("translates move names to localized round announcement", () => {
+      const setMessageSpy = jest.spyOn(view, "setMessage");
+
+      view.announceRound("Rock", "Paper");
+
+      expect(setMessageSpy).toHaveBeenCalledWith(
+        "You played Rock. Computer played Paper.",
+      );
+    });
+
+    it("handles different move combinations correctly", () => {
+      const setMessageSpy = jest.spyOn(view, "setMessage");
+
+      view.announceRound("Scissors", "Scissors");
+
+      expect(setMessageSpy).toHaveBeenCalledWith(
+        "You played Scissors. Computer played Scissors.",
+      );
+    });
+
+    it("works with capitalized move names", () => {
+      const setMessageSpy = jest.spyOn(view, "setMessage");
+
+      view.announceRound("ROCK", "PAPER");
+
+      expect(setMessageSpy).toHaveBeenCalledWith(
+        "You played ROCK. Computer played PAPER.",
+      );
+    });
+  });
+
+  /**
+   * Behavior verification: Ensures the view properly handles all game flow states
+   */
+  describe("Game Flow State Transitions", () => {
+    it("handles typical game flow: READY → PREPARE → CHOOSE → LOCK_IN → ROUND_RESULT", () => {
+      const setMessageSpy = jest.spyOn(view, "setMessage");
+
+      view.handleEvent({ type: "READY" });
+      expect(setMessageSpy).toHaveBeenLastCalledWith("Get ready...");
+
+      view.handleEvent({ type: "PREPARE" });
+      expect(setMessageSpy).toHaveBeenLastCalledWith(
+        "Prepare your next move...",
+      );
+
+      view.handleEvent({ type: "CHOOSE" });
+      expect(setMessageSpy).toHaveBeenLastCalledWith("Choose your attack!");
+
+      view.handleEvent({ type: "LOCK_IN" });
+      expect(setMessageSpy).toHaveBeenLastCalledWith("Locking in move...");
+
+      view.announceRound("Rock", "Paper");
+      expect(setMessageSpy).toHaveBeenLastCalledWith(
+        "You played Rock. Computer played Paper.",
+      );
+
+      expect(setMessageSpy).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/src/views/status/StatusView.ts
+++ b/src/views/status/StatusView.ts
@@ -1,11 +1,25 @@
 import View from "../View";
-import { IStatusView, StatusViewData } from "./IStatusView";
+import { IStatusView, StatusViewData, StatusViewEvent } from "./IStatusView";
+import { t } from "../../utils/i18n";
 
+/**
+ * Status View displays game state messages to the player.
+ *
+ * ## Responsibility
+ *
+ * StatusView owns the mapping between semantic events/data and localized UI text.
+ * This keeps text concerns (i18n, formatting) isolated from game logic.
+ *
+ * ## Examples
+ *
+ * - `handleEvent({ type: "READY" })` → translates to "Get ready..."
+ * - `announceRound("Rock", "Paper")` → translates to "You played Rock. Computer played Paper."
+ */
 export default class StatusView
   extends View<StatusViewData>
   implements IStatusView
 {
-  protected declare _parentElement: HTMLElement;
+  declare protected _parentElement: HTMLElement;
   private _messageElement: HTMLElement | null = null;
 
   public render(data: StatusViewData): void {
@@ -27,6 +41,51 @@ export default class StatusView
       // Fallback in case setMessage is called before render
       const el = document.getElementById("status");
       if (el) el.textContent = message;
+    }
+  }
+
+  /**
+   * Handles semantic events by translating them to localized messages.
+   *
+   * The Controller sends events, the View decides what text to display.
+   */
+  public handleEvent(event: StatusViewEvent): void {
+    const message = this.translateEvent(event);
+    this.setMessage(message);
+  }
+
+  /**
+   * Announces a round result by translating move names to a localized message.
+   * Demonstrates data-driven pattern: Controller passes data, View handles translation.
+   */
+  public announceRound(playerMove: string, computerMove: string): void {
+    const message = t("status_roundResult", {
+      playerMove,
+      computerMove,
+    });
+    this.setMessage(message);
+  }
+
+  /**
+   * Helper: Translates a semantic event to its localized message.
+   * Extracted for clarity and testability.
+   * @private
+   */
+  private translateEvent(event: StatusViewEvent): string {
+    switch (event.type) {
+      case "READY":
+        return t("status_ready");
+      case "LOCK_IN":
+        return t("status_lockIn");
+      case "PREPARE":
+        return t("status_prepare");
+      case "CHOOSE":
+        return t("status_choose");
+      case "CUSTOM":
+        return event.message;
+      default:
+        const _exhaustive: never = event;
+        throw new Error(`Unhandled event type: ${_exhaustive}`);
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "types": ["jest"],
     "allowImportingTsExtensions": true,
     "noEmit": true


### PR DESCRIPTION
Enforces stricter MVC boundaries by moving UI text generation out of the `Controller` and into the `View` layer. It introduces a lightweight localization system (`i18n.ts`) and shifts the application to an event-driven presentation model.

**Key Changes:**
- **🌐 Added i18n Utility:** Created `src/utils/i18n.ts` and src/locales/en.json. The t() helper supports mustache-style string interpolation ({{variable}}).
- **🧠 Smart Views:** `StatusView` and `ArenaView` now receive semantic events (e.g., `{ type: 'LOCK_IN' }`) or raw game state (e.g., `RoundResult`) and internally determine which text to display.
- **🧹 Controller Cleanup:** Stripped all string formatting and UI text from `controller.ts`. The controller is now strictly focused on state orchestration and timing.
- **💥 Impact Frame Polish:** Added `updateHealth` to `StatsView` to target specific DOM elements. This allows health bars to chunk down immediately on the visual impact frame without destroying the `innerHTML` and breaking CSS card animations.
- **🧪 Interpretation Tests:** Added specific `*.interpretation.test.ts` files for Views to ensure they correctly map game states to localization events. Replaced `querySelector` with `_getElement` in View helpers for strict null-checking during tests.

**Testing:**
- All unit tests passing.
- Verified that the "impact frame" timing correctly triggers the health bar drop and the text flash simultaneously.