### PR TITLE
RPST-93: feat: add floating combat text for damage feedback

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -817,3 +817,44 @@ button:focus-visible {
     transform: translate3d(6px, 0, 0);
   }
 }
+
+/* =============================================================================
+   9. COMBAT TEXT (FLOATING DAMAGE)
+   ============================================================================= */
+.floating-damage {
+  position: fixed;
+  z-index: 9999; /* High index to ensure it sits on top of everything */
+  pointer-events: none;
+
+  font-family: sans-serif;
+  font-weight: 900;
+  font-size: 1.75rem;
+  color: #fff;
+
+  /* Harder stroke to cut through dark/gray defeated cards */
+  -webkit-text-stroke: 2px var(--color-danger);
+  text-shadow: 0 0 10px rgba(255, 0, 0, 0.8);
+
+  animation: float-damage 1.5s cubic-bezier(0.1, 0.8, 0.2, 1) forwards;
+}
+
+@keyframes float-damage {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 0) scale(0.5);
+  }
+  20% {
+    opacity: 1;
+    transform: translate(-50%, -60px) scale(1.3); /* Big pop */
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -150px) scale(0.8); /* Higher float */
+  }
+}
+
+@media (min-width: 768px) {
+  .floating-damage {
+    font-size: 2.5rem;
+  }
+}

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -162,6 +162,7 @@ export class Controller {
         computerMoveId: computerMove,
         winner: roundResult.winner,
         isDoubleKO: roundResult.isDoubleKO,
+        damage: roundResult.damageCalculated,
       },
       () => {
         // 💥 IMPACT FRAME 💥

--- a/src/views/arena/ArenaView.test.ts
+++ b/src/views/arena/ArenaView.test.ts
@@ -322,4 +322,100 @@ describe("ArenaView", () => {
       expect(arenaShakeTriggered).toBe(false);
     });
   });
+
+  describe("Combat Text (Floating Damage)", () => {
+    beforeEach(() => {
+      // Inject the required DOM structure that ArenaView expects
+      document.body.innerHTML = `
+        <div id="arena">
+          <div id="move-reveal">
+            <div id="reveal-player"></div>
+            <div id="reveal-computer"></div>
+          </div>
+        </div>
+      `;
+
+      // Helper to mock card geometry
+      const setupCardMock = (id: string) => {
+        const card = document.getElementById(id);
+        if (card) {
+          card.getBoundingClientRect = () =>
+            ({
+              top: 10,
+              left: 10,
+              width: 100,
+              height: 100,
+              bottom: 110,
+              right: 110,
+              x: 10,
+              y: 10,
+              toJSON: () => {},
+            }) as DOMRect;
+        }
+      };
+
+      setupCardMock("reveal-player");
+      setupCardMock("reveal-computer");
+    });
+
+    it("should spawn a floating damage element containing the calculated damage", async () => {
+      const data = {
+        phase: "result" as const,
+        playerMoveId: "paper" as Move,
+        computerMoveId: "rock" as Move,
+        winner: "player" as const,
+        isDoubleKO: false,
+        announcementMessage: "PLAYER WINS!",
+        damage: 25,
+      };
+
+      await view.playRoundSequence(data);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const floatingTexts = document.querySelectorAll(".floating-damage");
+      expect(floatingTexts.length).toBe(1);
+      expect(floatingTexts[0].textContent).toBe("-25");
+    });
+
+    it("should spawn two floating damage elements during a double KO", async () => {
+      const data = {
+        phase: "result" as const,
+        playerMoveId: "rock" as Move,
+        computerMoveId: "paper" as Move,
+        winner: "tie" as const,
+        isDoubleKO: true,
+        announcementMessage: "DOUBLE KO!",
+        damage: 50,
+      };
+
+      await view.playRoundSequence(data);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const floatingTexts = document.querySelectorAll(".floating-damage");
+      expect(floatingTexts.length).toBe(2);
+      expect(floatingTexts[0].textContent).toBe("-50");
+      expect(floatingTexts[1].textContent).toBe("-50");
+    });
+
+    it("should clean up floating damage elements after the animation ends", async () => {
+      const data = {
+        phase: "result" as const,
+        playerMoveId: "paper" as Move,
+        computerMoveId: "rock" as Move,
+        winner: "player" as const,
+        isDoubleKO: false,
+        announcementMessage: "PLAYER WINS!",
+        damage: 25,
+      };
+
+      await view.playRoundSequence(data);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const floater = document.querySelector(".floating-damage");
+      floater?.dispatchEvent(new Event("animationend"));
+
+      const floatingTexts = document.querySelectorAll(".floating-damage");
+      expect(floatingTexts.length).toBe(0);
+    });
+  });
 });

--- a/src/views/arena/ArenaView.ts
+++ b/src/views/arena/ArenaView.ts
@@ -143,28 +143,52 @@ export default class ArenaView
     await this.executeOutcomeDrama(data);
   }
 
+  private spawnDamageText(targetCard: HTMLElement, damageValue: number): void {
+    const rect = targetCard.getBoundingClientRect();
+    const floater = document.createElement("div");
+
+    floater.textContent = `-${damageValue}`;
+    floater.classList.add("floating-damage");
+
+    floater.style.position = "fixed";
+    floater.style.left = `${rect.left + rect.width / 2}px`;
+    floater.style.top = `${rect.top + rect.height / 2}px`;
+
+    document.body.appendChild(floater);
+    floater.addEventListener("animationend", () => floater.remove());
+  }
+
   private async executeOutcomeDrama(data: ArenaViewData): Promise<void> {
-    // Get fresh element references after DOM update
-    const pCard = this._getElement("reveal-player");
-    const cCard = this._getElement("reveal-computer");
+    const playerCard = this._getElement("reveal-player");
+    const computerCard = this._getElement("reveal-computer");
     const container = this._getElement("move-reveal");
+    const damage = data.damage || 0;
+
+    // Helper to spawn damage
+    const hit = (card: HTMLElement) => {
+      if (damage > 0) this.spawnDamageText(card, damage);
+      card.classList.add("card-impact", "card-defeated");
+    };
 
     if (data.isDoubleKO || data.winner === "tie") {
-      pCard.classList.add("card-impact", "card-defeated");
-      cCard.classList.add("card-impact", "card-defeated");
+      // Both take damage in a tie/double KO
+      hit(playerCard);
+      hit(computerCard);
       container.classList.add("arena-shake");
-      await this._waitForAnimation(pCard);
+      await this._waitForAnimation(playerCard);
       return;
     }
 
-    const winningCard = data.winner === PARTICIPANTS.PLAYER ? pCard : cCard;
-    const losingCard = data.winner === PARTICIPANTS.PLAYER ? cCard : pCard;
-
-    losingCard.classList.add("card-impact", "card-defeated");
+    // Standard Win/Loss
+    const losingCard =
+      data.winner === PARTICIPANTS.PLAYER ? computerCard : playerCard;
+    hit(losingCard);
     container.classList.add("arena-shake");
-
     await this._waitForAnimation(losingCard);
 
+    // Winner gets highlight
+    const winningCard =
+      data.winner === PARTICIPANTS.PLAYER ? playerCard : computerCard;
     winningCard.classList.add("winner-highlight");
     await this._waitForAnimation(winningCard);
   }

--- a/src/views/arena/IArenaView.ts
+++ b/src/views/arena/IArenaView.ts
@@ -24,6 +24,7 @@ export interface ArenaViewData {
   winner?: Participant | "tie" | null;
   isDoubleKO?: boolean;
   announcementMessage?: string;
+  damage?: number;
 }
 
 /**


### PR DESCRIPTION
Introduces visual "floating damage" numbers to the arena, providing immediate feedback when a card takes damage during a round resolution.

**Changes:**
- **CSS:** Added `.floating-damage` styles and the `float-damage` keyframe animation for a snappy "pop and drift" effect.
- **Interface:** Updated `IArenaView` to include the `damage` payload.
- **Controller:** Updated round result data to include `damageCalculated`.
- **View:** Implemented `spawnDamageText` to handle the dynamic creation, absolute positioning, and lifecycle of floating text elements.
- **Tests:** Added a new test suite to `ArenaView.test.ts` ensuring damage correctly displays on both single and double KO scenarios and cleans up after `animationend`.