### PR TITLE
RPST-98: feat(ui): convert common move text indicators to static icon slots with strict type constraints

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -961,3 +961,84 @@ button:focus-visible {
     height: 32px;
   }
 }
+
+/* =============================================================================
+   11. COMMON MOVE SLOT
+   ============================================================================= */
+
+.common-move-wrapper {
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+  gap: 0.25rem;
+}
+
+/* Modifier classes for alignment */
+.common-move-wrapper.left-aligned {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.common-move-wrapper.right-aligned {
+  align-items: flex-end;
+  text-align: right;
+}
+
+/* Match the styling of your card labels for visual consistency */
+.common-move-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* The actual "slot" placeholder */
+.common-move-slot {
+  /* Match tara-icon-wrapper sizing */
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* Creates the "empty slot" look */
+  background-color: rgba(0, 0, 0, 0.03);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+}
+
+.common-icon-slot {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.common-icon-slot .icon-image,
+.common-icon-slot .icon-emoji {
+  width: 75%;
+  height: 75%;
+  object-fit: contain;
+  line-height: 1;
+  filter: opacity(0.85);
+}
+
+/* Desktop sizing */
+@media (min-width: 768px) {
+  .common-move-wrapper {
+    margin-top: 0.75rem;
+  }
+
+  .common-move-label {
+    font-size: 0.75rem;
+  }
+
+  .common-move-slot {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/src/model/IModel.ts
+++ b/src/model/IModel.ts
@@ -4,6 +4,7 @@ import {
   Move,
   Participant,
   RoundResult,
+  StandardMove,
 } from "../utils/dataObjectUtils";
 
 export interface IModel {
@@ -29,8 +30,8 @@ export interface IModel {
   taraIsEnabled(): boolean;
 
   // Most common moves
-  getPlayerMostCommonMove(): Move | null;
-  getComputerMostCommonMove(): Move | null;
+  getPlayerMostCommonMove(): StandardMove | null;
+  getComputerMostCommonMove(): StandardMove | null;
   showMostCommonMove(): boolean;
 
   // Match & round

--- a/src/views/stats/IStatsView.ts
+++ b/src/views/stats/IStatsView.ts
@@ -1,4 +1,4 @@
-import { Health, Move } from "../../utils/dataObjectUtils";
+import { Health, StandardMove } from "../../utils/dataObjectUtils";
 
 export interface StatsViewData {
   playerHealth: Health;
@@ -7,8 +7,8 @@ export interface StatsViewData {
   computerScore: number;
   playerTara: number;
   computerTara: number;
-  playerMostCommonMove: Move | null;
-  computerMostCommonMove: Move | null;
+  playerMostCommonMove: StandardMove | null;
+  computerMostCommonMove: StandardMove | null;
   matchNumber: number;
   roundNumber: number;
 }

--- a/src/views/stats/StatsView.test.ts
+++ b/src/views/stats/StatsView.test.ts
@@ -63,13 +63,20 @@ describe("StatsView", () => {
       ).toBe("Match 1");
     });
 
-    test("formats null common moves as '–'", () => {
-      view.update(defaultData);
-      // Fix: target the last span
-      expect(
-        document.querySelector("#player-stats small span:last-child")!
-          .textContent,
-      ).toBe("–");
+    test("hides all signature move icons when common move is null", () => {
+      view.update(defaultData); // defaultData has null for most common moves
+
+      // Query for any signature slots that DO NOT have the 'hidden' class
+      const playerVisibleIcons = document.querySelectorAll(
+        "#player-stats .signature-icon-slot:not(.hidden)",
+      );
+      const computerVisibleIcons = document.querySelectorAll(
+        "#computer-stats .signature-icon-slot:not(.hidden)",
+      );
+
+      // Since the move is null, no icons should be visible (length of 0)
+      expect(playerVisibleIcons.length).toBe(0);
+      expect(computerVisibleIcons.length).toBe(0);
     });
 
     test("updates health bar width attributes without replacing elements (diff on subsequent calls)", () => {
@@ -110,7 +117,7 @@ describe("StatsView", () => {
       ).toBe("12");
     });
 
-    test("updates most common moves", () => {
+    test("updates most common moves by toggling the hidden class on the correct icon slot", () => {
       // First call does initial render
       view.update(defaultData);
 
@@ -122,14 +129,28 @@ describe("StatsView", () => {
       };
       view.update(newData);
 
-      expect(
-        document.querySelector("#player-stats small span:last-child")!
-          .textContent,
-      ).toBe(MOVES.ROCK);
-      expect(
-        document.querySelector("#computer-stats small span:last-child")!
-          .textContent,
-      ).toBe(MOVES.PAPER);
+      // Select specific move slots for both players based on the data-move attribute
+      const playerRockSlot = document.querySelector(
+        '#player-stats .common-icon-slot[data-move="rock"]',
+      )!;
+      const playerPaperSlot = document.querySelector(
+        '#player-stats .common-icon-slot[data-move="paper"]',
+      )!;
+
+      const computerPaperSlot = document.querySelector(
+        '#computer-stats .common-icon-slot[data-move="paper"]',
+      )!;
+      const computerRockSlot = document.querySelector(
+        '#computer-stats .common-icon-slot[data-move="rock"]',
+      )!;
+
+      // Player checks: Rock should be visible, Paper should be hidden
+      expect(playerRockSlot.classList.contains("hidden")).toBe(false);
+      expect(playerPaperSlot.classList.contains("hidden")).toBe(true);
+
+      // Computer checks: Paper should be visible, Rock should be hidden
+      expect(computerPaperSlot.classList.contains("hidden")).toBe(false);
+      expect(computerRockSlot.classList.contains("hidden")).toBe(true);
     });
 
     test("renders tara icons using the shared move definition", () => {

--- a/src/views/stats/StatsView.ts
+++ b/src/views/stats/StatsView.ts
@@ -1,7 +1,13 @@
 import View from "../View";
 import { IStatsView, StatsViewData } from "./IStatsView";
 import { renderIcon } from "../../utils/imageUtils";
-import { MAX_TARA, MOVES_DATABASE } from "../../utils/dataUtils";
+import {
+  MAX_TARA,
+  MOVES_DATABASE,
+  PLAYER_MOVES_DATA,
+  STANDARD_MOVE_NAMES,
+  StandardMove,
+} from "../../utils/dataUtils";
 
 export default class StatsView
   extends View<StatsViewData>
@@ -62,6 +68,38 @@ export default class StatsView
     return iconsMarkup;
   }
 
+  private _generateCommonMoveSlot(
+    moveId: StandardMove | null | undefined,
+    alignment: "left" | "right",
+  ): string {
+    let allIconsMarkup = "";
+
+    STANDARD_MOVE_NAMES.forEach((standardMove) => {
+      const moveObj = PLAYER_MOVES_DATA.find((m) => m.id === standardMove);
+
+      if (moveObj) {
+        // Only remove the hidden class if it matches the current moveId
+        const isCurrentMove = moveId === standardMove;
+        const hiddenClass = isCurrentMove ? "" : "hidden";
+
+        allIconsMarkup += `
+          <div class="common-icon-slot ${hiddenClass}" data-move="${standardMove}">
+            ${renderIcon(moveObj.icon)}
+          </div>
+        `;
+      }
+    });
+
+    return `
+      <div class="common-move-wrapper ${alignment}-aligned">
+        <span class="common-move-label">COMMON MOVE</span>
+        <div class="common-move-slot">
+          ${allIconsMarkup}
+        </div>
+      </div>
+    `;
+  }
+
   protected _generateMarkup(): string {
     const {
       playerHealth,
@@ -89,7 +127,7 @@ export default class StatsView
           ${this._generateTaraIcons(playerTara)}
         </div>
 
-        <p><small><span>Common: </span><span>${playerMostCommonMove ?? "–"}</span></small></p>
+        ${this._generateCommonMoveSlot(playerMostCommonMove, "left")}
       </aside>
 
       <section id="game-progress-container">
@@ -109,7 +147,7 @@ export default class StatsView
           ${this._generateTaraIcons(computerTara)}
         </div>
 
-        <p><small><span>Common: </span><span>${computerMostCommonMove ?? "–"}</span></small></p>
+        ${this._generateCommonMoveSlot(computerMostCommonMove, "right")}
       </aside>
     `;
   }


### PR DESCRIPTION
Transitions the "Most Common Move" feature from a simple string literal element down to a robust, static icon-based placeholder slot system.

**Key Technical Transitions**
- **Strict Type Assertions:** Restricts tracked usage down exclusively to `StandardMove` items in `IModel` and `IStatsView` layouts, avoiding unintended special asset rendering crashes downstream.
- **DOM-Diff Optimization:** Rather than introducing layout reflow changes when swapping nodes mid-match, the updated view pre-renders individual standard attack icons inside `.common-move-slot `structures, managing state entirely via `.hidden` class manipulations.
- **Mobile-Responsive Interface Addition:** Appends layout structure styling parameters to `style.css` allowing for clean left/right grid orientation placements underneath the active participant's vitals.
- **Integration Checks:** Replaces deprecated `.textContent` expectation calls across `StatsView.test.ts` suites with structural `.signature-icon-slot` attribute evaluation passes.