### PR TITLE
RPST-99: feat(ui): hide selected move card while preserving layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -352,6 +352,12 @@ main {
   cursor: not-allowed;
 }
 
+.card-button.is-hidden,
+.card-button.is-hidden:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .card-button:disabled .card-front {
   filter: grayscale(0.9) contrast(0.9);
   opacity: 0.7;

--- a/src/views/controls/ControlsView.test.ts
+++ b/src/views/controls/ControlsView.test.ts
@@ -133,6 +133,26 @@ describe("ControlsView", () => {
     expect(handler).toHaveBeenCalledWith(MOVES.PAPER);
   });
 
+  test("hides and disables the clicked move card after selection", async () => {
+    const handler = jest.fn();
+    view.bindPlayerMove(handler);
+    view.render({
+      playerMove: null,
+      isMatchOver: false,
+      taraIsEnabled: true,
+      moves: mockMoves,
+    });
+
+    await view.flipAll(true);
+    const rockButton = document.getElementById(MOVES.ROCK) as HTMLButtonElement;
+
+    rockButton.click();
+
+    expect(handler).toHaveBeenCalledWith(MOVES.ROCK);
+    expect(rockButton.classList.contains("is-hidden")).toBe(true);
+    expect(rockButton.disabled).toBe(true);
+  });
+
   test("renders move buttons when match is NOT over", () => {
     view.render({
       playerMove: null,

--- a/src/views/controls/ControlsView.ts
+++ b/src/views/controls/ControlsView.ts
@@ -113,6 +113,8 @@ export default class ControlsView
 
       const moveBtn = target.closest(".card-button") as HTMLButtonElement;
       if (moveBtn && !moveBtn.disabled && this._moveHandler) {
+        moveBtn.classList.add("is-hidden");
+        moveBtn.disabled = true;
         this._moveHandler(moveBtn.id as Move);
       }
     };


### PR DESCRIPTION
Hides a clicked move card instantly (optimistic UI) to confirm selection without collapsing the flex container.

### Changes:
- **CSS:** Added `.card-button.is-hidden` and `.card-button.is-hidden:disabled` with `opacity: 0; pointer-events: none;`. This specifically overrides the existing `:disabled` grayscale styling that was keeping the card visible.
- **View:** Updated the click listener in `ControlsView.ts` to immediately add the `is-hidden` class and `disabled = true` to the selected button before the controller processes the move.
- **Tests:** Added hides and disables the clicked move card after selection test to `ControlsView.test.ts`.