### PR TITLE
RPST-101: ci: add typescript compilation check and build artifact uploads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,8 +7,8 @@ on:
     branches: ["main"]
 
 jobs:
-  test:
-    name: Run Jest Unit Tests
+  test-and-build:
+    name: CI Checks
     runs-on: ubuntu-latest
 
     steps:
@@ -26,3 +26,13 @@ jobs:
 
       - name: Execute Tests
         run: npm run test
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Upload Build Artifacts
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts
+          path: dist/


### PR DESCRIPTION
- Updates `.github/workflows/ci-cd.yml` to run `npm run build` sequentially after tests.
- Consolidates the pipeline into a single `CI Checks` job to optimize workflow runtime.
- Restricts PR merges on compilation or syntax errors caught during the Parcel build step.
- Configures `actions/upload-artifact@v4` to securely archive the `dist/` directory exclusively on `main` branch pushes.