### PR TITLE
RPST-102: ci: automate continuous deployment to github pages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,3 +36,23 @@ jobs:
         with:
           name: dist-artifacts
           path: dist/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: test-and-build
+    # Executes ONLY on main AND if the commit message DOES NOT contain [skip deploy]
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip deploy]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-artifacts
+          path: dist/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
- Appends a `deploy` job to the CI/CD pipeline that requires `test-and-build` to pass.
- Implements conditional logic to restrict deployments exclusively to `main` branch merges.
- Configures `actions/download-artifact@v4` to retrieve the Parcel `dist/` build.
- Utilizes `peaceiris/actions-gh-pages@v4` to automatically push the compiled assets to the `gh-pages` branch for hosting.