### PR TITLE
[deploy skip] RPST-103: Initialize and Harden Playwright E2E Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ Thumbs.db
 
 # IDE or editor configurations
 .vscode/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@parcel/config-default": "^2.16.3",
         "@parcel/reporter-dev-server": "^2.16.3",
         "@parcel/transformer-typescript-tsc": "^2.14.1",
+        "@playwright/test": "^1.61.1",
         "@types/jest": "^29.5.14",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
         "@typescript-eslint/parser": "^8.27.0",
         "eslint": "^9.23.0",
@@ -12752,6 +12754,22 @@
         "@parcel/core": "^2.14.1"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -13171,13 +13189,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -17393,6 +17411,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -18248,9 +18313,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "build": "npx parcel build public/index.html --dist-dir dist --public-url /rock-paper-scissors-tara/",
     "start": "npx parcel serve public/index.html --open",
-    "test": "jest",
     "lint": "eslint 'src/**/*.ts'",
-    "lint:fix": "eslint 'src/**/*.ts' --fix"
+    "lint:fix": "eslint 'src/**/*.ts' --fix",
+    "test": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
   },
   "keywords": [],
   "author": "Tara Timmerman",
@@ -17,7 +20,9 @@
     "@parcel/config-default": "^2.16.3",
     "@parcel/reporter-dev-server": "^2.16.3",
     "@parcel/transformer-typescript-tsc": "^2.14.1",
+    "@playwright/test": "^1.61.1",
     "@types/jest": "^29.5.14",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
     "eslint": "^9.23.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,36 +2,29 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-
-  /* Run tests in files in parallel */
   fullyParallel: true,
 
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  /* Prevent merging skipped test suites with test.only active */
   forbidOnly: !!process.env.CI,
 
-  /* Retry flakiness in CI, but never locally (forces devs to fix their tests) */
+  /* Retry failures on CI to mitigate network or infrastructure flakiness */
   retries: process.env.CI ? 2 : 0,
 
-  /* CI runners often choke on CPU-heavy browser processes. Limit workers in CI. */
+  /* Limit resource consumption on single-core CI runners */
   workers: process.env.CI ? 1 : undefined,
 
-  /*
-   * QoL: Use 'list' for a clean terminal output.
-   * Generate an 'html' report, but don't auto-open it every time a test fails locally.
-   */
+  /* Output test status to stdout and generate an HTML report without auto-opening */
   reporter: [["list"], ["html", { open: "never" }]],
 
   use: {
-    /* Points to your Parcel dev server. Simplifies navigation: await page.goto('/') */
     baseURL: "http://localhost:1234",
 
-    /* SDET Best Practice: Capture full debugging context ONLY when tests fail to save CI disk space */
+    /* Capture debugging contexts only on failure to optimize CI artifact storage */
     trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",
@@ -47,12 +40,11 @@ export default defineConfig({
     },
   ],
 
-  /* Automatically manage the Parcel server lifecycle */
+  /* Automate the local Parcel server lifecycle during execution */
   webServer: {
     command: "npm run start",
     url: "http://localhost:1234",
     reuseExistingServer: !process.env.CI,
-    /* 2 minutes: gives Parcel plenty of time for initial caching/bundling on a cold start */
-    timeout: 120 * 1000,
+    timeout: 120 * 1000 /* Allow sufficient time for cold start bundling */,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry flakiness in CI, but never locally (forces devs to fix their tests) */
+  retries: process.env.CI ? 2 : 0,
+
+  /* CI runners often choke on CPU-heavy browser processes. Limit workers in CI. */
+  workers: process.env.CI ? 1 : undefined,
+
+  /*
+   * QoL: Use 'list' for a clean terminal output.
+   * Generate an 'html' report, but don't auto-open it every time a test fails locally.
+   */
+  reporter: [["list"], ["html", { open: "never" }]],
+
+  use: {
+    /* Points to your Parcel dev server. Simplifies navigation: await page.goto('/') */
+    baseURL: "http://localhost:1234",
+
+    /* SDET Best Practice: Capture full debugging context ONLY when tests fail to save CI disk space */
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+
+  /* Automatically manage the Parcel server lifecycle */
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:1234",
+    reuseExistingServer: !process.env.CI,
+    /* 2 minutes: gives Parcel plenty of time for initial caching/bundling on a cold start */
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,20 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["jest"],
+    "types": ["jest", "node"],
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src", "**/*.test.ts", "**/*.test.tsx"]
+  "include": [
+    "src",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "playwright.config.ts",
+    "tests/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## 🎯 Objective
This PR establishes the foundational infrastructure for our End-to-End (E2E) testing using Playwright. This is strictly an infrastructure/setup MR (no game logic tests are included yet). 

The goal is to ensure Playwright reliably boots our local Parcel server, executes tests with the correct TypeScript configurations, and cleanly shuts down without leaving orphaned processes or committing heavy artifacts.

## 🛠️ Key Changes
* **Playwright Configuration (`playwright.config.ts`):** 
  * Added production-ready SDET configurations including CI-specific retries, parallel execution, and artifact retention rules (`retain-on-failure`).
  * Configured the `webServer` block to automatically manage the Parcel dev server (`localhost:1234`) lifecycle during test runs.
* **TypeScript Fixes (`tsconfig.json`):** 
  * Added `@types/node` and updated the `types` array to resolve `process.env` errors.
  * Removed the restrictive `rootDir` property and updated the `include` array so the TypeScript server correctly analyzes the `playwright.config.ts` file and the new `tests/e2e` directory.
* **NPM Scripts (`package.json`):** Added standard execution scripts (`test:e2e`, `test:e2e:ui`, `test:e2e:debug`) to standardize the developer experience.
* **Version Control (`.gitignore`):** Ignored Playwright artifacts (reports, traces, test results) to prevent repository bloat on failed test runs.
* **Boilerplate Test (`example.spec.ts`):** Included a temporary dummy test just to prove the runner and configurations work end-to-end.

## 🧪 How to Verify
1. Pull this branch down locally and run `npm install`.
2. Run `npm run test:e2e`.
3. Verify that the command automatically boots the Parcel server, runs the dummy test successfully, and exits cleanly.
4. (Optional) Run `npm run test:e2e:ui` to verify the interactive Playwright dashboard opens successfully.