### PR TITLE
[skip deploy] RPST-105: ci: automate Playwright E2E test execution and block failing deployments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,8 +24,14 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
       - name: Execute Tests
         run: npm run test
+
+      - name: Execute E2E Tests
+        run: npm run test:e2e
 
       - name: Build Project
         run: npm run build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Execute E2E Tests
         run: npm run test:e2e
 
+      - name: Upload Playwright Report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
       - name: Build Project
         run: npm run build
 


### PR DESCRIPTION
## Context
Currently, E2E tests are executed locally but not enforced during the continuous integration process. This creates a risk of regression bugs slipping into the `main` branch and deploying to production.

## Changes Included
*   **Playwright Integration:** Added a step to install Playwright browser binaries (`--with-deps`) within the Ubuntu runner.
*   **Pipeline Execution:** Positioned the `npm run test:e2e` execution immediately following unit tests, serving as a strict gatekeeper before the build step.
*   **Artifact Retention:** Implemented an always-run artifact upload step for `playwright-report` to retain DOM snapshots and trace files for 7 days if a test fails in CI.

## Acceptance Criteria Verified
- [x] Workflow triggers correctly on PR creation.
- [x] Chromium, Firefox, and WebKit binaries download successfully.
- [x] Pipeline halts and blocks deployment if an E2E test fails.
- [x] Test artifacts are available for debugging on failure.