### PR TITLE
[skip deploy] RPST-106: feat(e2e): Add parameterized stats verification and parallelize assertions

### DIFF
--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,13 +1,35 @@
 import { test } from "../baseTest";
+import { Participant } from "../models/GamePage";
 
-test("should load the initial game UI successfully", async ({
+test("loads default match UI with no saved game state", async ({
   gamePage,
   landingPage,
 }) => {
-  await landingPage.verifyHeadingVisible();
-  await landingPage.startMatch();
-  await landingPage.verifyHeadingVisible(false);
+  const defaultStats = {
+    availableTaraMoves: 0,
+    health: 100,
+    wins: "00",
+    commonMove: null,
+  };
 
-  await gamePage.verifyPlayerButtonsVisible();
-  await gamePage.verifyTaraEnabled(false);
+  const defaultProgress = {
+    match: 1,
+    round: 1,
+  };
+
+  await test.step("Start match from landing page", async () => {
+    await landingPage.verifyHeadingVisible();
+    await landingPage.startMatch();
+    await landingPage.verifyHeadingVisible(false);
+  });
+
+  await test.step("Verify default initial game state", async () => {
+    await Promise.all([
+      gamePage.verifyStats(Participant.PLAYER, defaultStats),
+      gamePage.verifyProgress(defaultProgress),
+      gamePage.verifyStats(Participant.COMPUTER, defaultStats),
+      gamePage.verifyPlayerButtonsVisible(),
+      gamePage.verifyTaraEnabled(false),
+    ]);
+  });
 });

--- a/tests/models/GamePage.ts
+++ b/tests/models/GamePage.ts
@@ -1,5 +1,7 @@
 import { expect, Locator, Page } from "@playwright/test";
 
+const MAX_TARA_MOVES = 3;
+
 export enum Move {
   PAPER = "paper",
   ROCK = "rock",
@@ -7,14 +9,38 @@ export enum Move {
   TARA = "tara",
 }
 
+export enum Participant {
+  COMPUTER = "computer",
+  PLAYER = "player",
+}
+
+export interface Progress {
+  match: number;
+  round: number;
+}
+
+export interface Stats {
+  availableTaraMoves: number;
+  commonMove: Move | null;
+  health: number;
+  wins: string;
+}
+
 export class GamePage {
   readonly page: Page;
 
+  readonly progressContainer: Locator;
+  readonly progressMatchHeading: Locator;
+  readonly progressRoundHeading: Locator;
   readonly statusContainer: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.statusContainer = this.page.locator("#status");
+
+    this.progressContainer = page.locator("#game-progress-container");
+    this.progressMatchHeading = this.progressContainer.locator("h2");
+    this.progressRoundHeading = this.progressContainer.locator("h3");
+    this.statusContainer = page.locator("#status");
   }
 
   // ====================================================
@@ -23,6 +49,41 @@ export class GamePage {
 
   playerAction(action: Move): Locator {
     return this.page.getByRole("button", { name: new RegExp(action, "i") });
+  }
+
+  statsContainer(participant: Participant): Locator {
+    return this.page.locator(`#${participant}-stats`);
+  }
+
+  statsCommonMoveContainer(participant: Participant): Locator {
+    return this.statsContainer(participant).locator(".common-move-slot");
+  }
+
+  statsCommonMoveIcon(participant: Participant, move: Move): Locator {
+    return this.statsContainer(participant).locator(
+      `.common-icon-slot[data-move="${move}"]`,
+    );
+  }
+
+  statsHealthBar(participant: Participant): Locator {
+    return this.page.locator(`#${participant}-health`);
+  }
+
+  statsTaraIcons(participant: Participant, isActive: boolean): Locator {
+    const stateSelector = isActive ? ":not(.tara-inactive)" : ".tara-inactive";
+    return this.page.locator(
+      `.${participant}-tara-container .tara-icon-wrapper${stateSelector}`,
+    );
+  }
+
+  statsVisibleCommonMoveIcons(participant: Participant): Locator {
+    return this.statsCommonMoveContainer(participant).locator(
+      ".common-icon-slot:not(.hidden)",
+    );
+  }
+
+  statsWins(participant: Participant): Locator {
+    return this.statsContainer(participant).locator(".score-row");
   }
 
   // ====================================================
@@ -34,7 +95,7 @@ export class GamePage {
   }
 
   // ====================================================
-  // VERIFICATION
+  // VERIFICATION MISCELLANEOUS
   // ====================================================
 
   async verifyPlayerActionAnnouncement(playerAction: Move): Promise<void> {
@@ -43,11 +104,23 @@ export class GamePage {
   }
 
   async verifyPlayerButtonsVisible(isVisible = true): Promise<void> {
-    for (const action of Object.values(Move)) {
-      await expect(this.playerAction(action)).toBeVisible({
-        visible: isVisible,
-      });
-    }
+    // Replaced for...of loop with parallel map
+    await Promise.all(
+      Object.values(Move).map((action) =>
+        expect(this.playerAction(action)).toBeVisible({ visible: isVisible }),
+      ),
+    );
+  }
+
+  async verifyProgress(progress: Progress): Promise<void> {
+    await Promise.all([
+      expect(this.progressMatchHeading).toContainText(
+        new RegExp(`match ${progress.match}`, "i"),
+      ),
+      expect(this.progressRoundHeading).toContainText(
+        new RegExp(`round ${progress.round}`, "i"),
+      ),
+    ]);
   }
 
   async verifyStatusVisible(isVisible = true): Promise<void> {
@@ -58,5 +131,85 @@ export class GamePage {
     await expect(this.playerAction(Move.TARA)).toBeEnabled({
       enabled: isEnabled,
     });
+  }
+
+  // ====================================================
+  // VERIFICATION STATS
+  // ====================================================
+
+  async verifyStats(
+    participant: Participant,
+    expectedStats: Stats,
+  ): Promise<void> {
+    await Promise.all([
+      this.verifyStatsWins(participant, expectedStats.wins),
+      this.verifyStatsHealth(participant, expectedStats.health),
+      this.verifyStatsTaraIcons(participant, expectedStats.availableTaraMoves),
+      this.verifyCommonMove(participant, expectedStats.commonMove),
+    ]);
+  }
+
+  private async verifyCommonMove(
+    participant: Participant,
+    expectedMove: Move | null,
+  ): Promise<void> {
+    if (expectedMove === null) {
+      await this.verifyStatsVisibleCommonMoveIcons(participant, 0);
+      return;
+    }
+
+    const moveIcon = this.statsCommonMoveIcon(participant, expectedMove);
+
+    await Promise.all([
+      this.verifyStatsVisibleCommonMoveIcons(participant, 1),
+      expect(moveIcon).not.toHaveClass(/hidden/),
+      expect(moveIcon).toBeVisible(),
+    ]);
+  }
+
+  private async verifyStatsVisibleCommonMoveIcons(
+    participant: Participant,
+    expectedCount: number,
+  ): Promise<void> {
+    await expect(this.statsVisibleCommonMoveIcons(participant)).toHaveCount(
+      expectedCount,
+    );
+  }
+
+  private async verifyStatsHealth(
+    participant: Participant,
+    expectedPercentage: number,
+  ): Promise<void> {
+    const styleRegex = new RegExp(`width:\\s*${expectedPercentage}%`, "i");
+    await expect(this.statsHealthBar(participant)).toHaveAttribute(
+      "style",
+      styleRegex,
+    );
+  }
+
+  private async verifyStatsTaraIcons(
+    participant: Participant,
+    expectedActiveIcons: number,
+  ): Promise<void> {
+    await Promise.all([
+      expect(this.statsTaraIcons(participant, true)).toHaveCount(
+        expectedActiveIcons,
+      ),
+      expect(this.statsTaraIcons(participant, false)).toHaveCount(
+        MAX_TARA_MOVES - expectedActiveIcons,
+      ),
+    ]);
+  }
+
+  private async verifyStatsWins(
+    participant: Participant,
+    expectedWins: string,
+  ): Promise<void> {
+    const statsWins = this.statsWins(participant);
+
+    await Promise.all([
+      expect(statsWins).toContainText("WINS"),
+      expect(statsWins).toContainText(expectedWins),
+    ]);
   }
 }


### PR DESCRIPTION
Significantly refactors the `GamePage` Page Object Model to support comprehensive game state validation while improving test execution efficiency and report readability.

### Key Changes:
- **Types & Enums:** Introduced `Participant`, `Stats`, and `Progress` models to strictly type the expected game state.
- **Parallel Assertions:** Avoided sequential `await` checks and `for...of` loops with `Promise.all()` (e.g., in `verifyPlayerButtonsVisible` and `verifyStats`) to evaluate independent DOM elements simultaneously.
- **Guard Clauses:** Implemented an early-return guard clause in `verifyCommonMove` to handle the `null` (empty slot) state cleanly before evaluating active UI elements.
- **Spec Updates (`landing.spec.ts`):**
  - Implemented `test.step()` groups for granular, readable Playwright reports.
  - Added full validation of the initial zero-state (100% health, 0 wins, 0 Tara moves, round 1) on game load.