### PR TITLE
[skip deploy] RPST-107: feat(e2e): Add localStorage seeding fixture and 'Continue Match' flow coverage

### DIFF
--- a/tests/baseTest.ts
+++ b/tests/baseTest.ts
@@ -1,10 +1,12 @@
 import { test as base } from "@playwright/test";
 import { LandingPage } from "./models/LandingPage";
 import { GamePage } from "./models/GamePage";
+import { GameStateSeed, seedStorage } from "./utils/localStorageSeed";
 
 type Page = {
   landingPage: LandingPage;
   gamePage: GamePage;
+  seed: (data: GameStateSeed) => Promise<void>;
 };
 
 export const test = base.extend<Page>({
@@ -17,6 +19,11 @@ export const test = base.extend<Page>({
   },
   gamePage: async ({ page }, use) => {
     await use(new GamePage(page));
+  },
+  seed: async ({ page }, use) => {
+    await use(async (data: GameStateSeed) => {
+      await seedStorage(page, data);
+    });
   },
 });
 

--- a/tests/baseTest.ts
+++ b/tests/baseTest.ts
@@ -1,12 +1,12 @@
 import { test as base } from "@playwright/test";
 import { LandingPage } from "./models/LandingPage";
 import { GamePage } from "./models/GamePage";
-import { GameStateSeed, seedStorage } from "./utils/localStorageSeed";
+import { SeedPayload, seedStorage } from "./utils/localStorageSeed";
 
 type Page = {
   landingPage: LandingPage;
   gamePage: GamePage;
-  seed: (data: GameStateSeed) => Promise<void>;
+  seed: (data: SeedPayload) => Promise<void>;
 };
 
 export const test = base.extend<Page>({
@@ -21,7 +21,7 @@ export const test = base.extend<Page>({
     await use(new GamePage(page));
   },
   seed: async ({ page }, use) => {
-    await use(async (data: GameStateSeed) => {
+    await use(async (data: SeedPayload) => {
       await seedStorage(page, data);
     });
   },

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,18 +1,18 @@
 import { test } from "../baseTest";
-import { Participant } from "../models/GamePage";
+import { Move, Participant, Progress, Stats } from "../models/GamePage";
 
 test("loads default match UI with no saved game state", async ({
   gamePage,
   landingPage,
 }) => {
-  const defaultStats = {
+  const defaultStats: Stats = {
     availableTaraMoves: 0,
-    health: 100,
-    wins: "00",
     commonMove: null,
+    health: 100,
+    wins: 0,
   };
 
-  const defaultProgress = {
+  const defaultProgress: Progress = {
     match: 1,
     round: 1,
   };
@@ -30,6 +30,53 @@ test("loads default match UI with no saved game state", async ({
       gamePage.verifyStats(Participant.COMPUTER, defaultStats),
       gamePage.verifyPlayerButtonsVisible(),
       gamePage.verifyTaraEnabled(false),
+    ]);
+  });
+});
+
+test("loads custom UI with seeded game state", async ({
+  gamePage,
+  landingPage,
+  seed,
+}) => {
+  const expectedProgress: Progress = {
+    match: 2,
+    round: 2,
+  };
+
+  const expectedPlayerStats: Stats = {
+    availableTaraMoves: 3,
+    commonMove: Move.ROCK,
+    health: 100,
+    wins: 1,
+  };
+
+  const expectedComputerStats: Stats = {
+    availableTaraMoves: 0,
+    commonMove: Move.SCISSORS,
+    health: 50,
+    wins: 0,
+  };
+
+  await seed({
+    progress: expectedProgress,
+    playerStats: expectedPlayerStats,
+    computerStats: expectedComputerStats,
+  });
+
+  await test.step("Continue match from landing page", async () => {
+    await landingPage.verifyHeadingVisible();
+    await landingPage.continueMatch();
+    await landingPage.verifyHeadingVisible(false);
+  });
+
+  await test.step("Verify UI renders with expected progress and stats", async () => {
+    await Promise.all([
+      gamePage.verifyStats(Participant.PLAYER, expectedPlayerStats),
+      gamePage.verifyProgress(expectedProgress),
+      gamePage.verifyStats(Participant.COMPUTER, expectedComputerStats),
+      gamePage.verifyPlayerButtonsVisible(),
+      gamePage.verifyTaraEnabled(),
     ]);
   });
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -34,7 +34,7 @@ test("loads default match UI with no saved game state", async ({
   });
 });
 
-test("loads custom UI with seeded game state", async ({
+test("loads custom match UI with seeded game state", async ({
   gamePage,
   landingPage,
   seed,

--- a/tests/models/GamePage.ts
+++ b/tests/models/GamePage.ts
@@ -21,9 +21,9 @@ export interface Progress {
 
 export interface Stats {
   availableTaraMoves: number;
-  commonMove: Move | null;
+  commonMove: Exclude<Move, Move.TARA> | null;
   health: number;
-  wins: string;
+  wins: number;
 }
 
 export class GamePage {
@@ -104,7 +104,6 @@ export class GamePage {
   }
 
   async verifyPlayerButtonsVisible(isVisible = true): Promise<void> {
-    // Replaced for...of loop with parallel map
     await Promise.all(
       Object.values(Move).map((action) =>
         expect(this.playerAction(action)).toBeVisible({ visible: isVisible }),
@@ -203,13 +202,16 @@ export class GamePage {
 
   private async verifyStatsWins(
     participant: Participant,
-    expectedWins: string,
+    expectedWins: number,
   ): Promise<void> {
     const statsWins = this.statsWins(participant);
 
+    // Formats 1 -> "01", 0 -> "00", but leaves 10 -> "10"
+    const formattedWins = expectedWins.toString().padStart(2, "0");
+
     await Promise.all([
       expect(statsWins).toContainText("WINS"),
-      expect(statsWins).toContainText(expectedWins),
+      expect(statsWins).toContainText(formattedWins),
     ]);
   }
 }

--- a/tests/models/LandingPage.ts
+++ b/tests/models/LandingPage.ts
@@ -3,12 +3,14 @@ import { expect, Locator, Page } from "@playwright/test";
 export class LandingPage {
   readonly page: Page;
 
+  readonly continueButton: Locator;
   readonly heading: Locator;
   readonly startButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
+    this.continueButton = page.getByRole("button", { name: /continue match/i });
     this.heading = page.getByRole("heading", {
       name: /rock paper scissors tara/i,
     });
@@ -18,6 +20,10 @@ export class LandingPage {
   // ====================================================
   // ACTIONS
   // ====================================================
+
+  async continueMatch(): Promise<void> {
+    await this.continueButton.click();
+  }
 
   async startMatch(): Promise<void> {
     await this.startButton.click();

--- a/tests/utils/localStorageSeed.ts
+++ b/tests/utils/localStorageSeed.ts
@@ -1,4 +1,3 @@
-// tests/utils/storageSeed.ts
 import { Page } from "@playwright/test";
 import { Move, Progress, Stats } from "../models/GamePage";
 

--- a/tests/utils/localStorageSeed.ts
+++ b/tests/utils/localStorageSeed.ts
@@ -1,77 +1,94 @@
+// tests/utils/storageSeed.ts
 import { Page } from "@playwright/test";
-import {
-  Match,
-  MoveCount,
-  Participant,
-  StandardMove,
-} from "../../src/utils/dataObjectUtils";
+import { Move, Progress, Stats } from "../models/GamePage";
 
-// 1. Define the optional seeding interfaces
-export interface ParticipantSeed {
-  score?: number;
-  taraCount?: number;
-  mostCommonMove?: StandardMove;
-  moveCounts?: MoveCount;
-}
-
-export interface GameStateSeed {
-  globalMatchNumber?: number;
-  currentMatch?: Match;
-  participants?: Partial<Record<Participant, ParticipantSeed>>;
+export interface SeedPayload {
+  progress?: Partial<Progress>;
+  playerStats?: Partial<Stats>;
+  computerStats?: Partial<Stats>;
 }
 
 /**
- * 2. The utility function to inject state into localStorage.
- * This runs inside the browser context, so all logic must be self-contained.
+ * Main action called by the Playwright fixture.
  */
 export async function seedStorage(
   page: Page,
-  seedData: GameStateSeed,
+  payload: SeedPayload,
 ): Promise<void> {
-  await page.evaluate((data) => {
-    // Clear existing storage to guarantee a clean slate
-    localStorage.clear();
+  // 1. Build the exact key/value dictionary in Node.js
+  const storageDictionary = buildStorageDictionary(payload);
 
-    // Set Globals
-    if (data.globalMatchNumber !== undefined) {
-      localStorage.setItem(
-        "globalMatchNumber",
-        data.globalMatchNumber.toString(),
+  // 2. Inject the flat dictionary into the browser's localStorage
+  await page.evaluate((dictionary) => {
+    localStorage.clear();
+    for (const [key, value] of Object.entries(dictionary)) {
+      localStorage.setItem(key, value);
+    }
+  }, storageDictionary);
+
+  // 3. Reload to hydrate the app
+  await page.reload();
+}
+
+/**
+ * Translates UI test models into the raw flat keys the application expects.
+ */
+function buildStorageDictionary(payload: SeedPayload): Record<string, string> {
+  const dictionary: Record<string, string> = {};
+
+  // --- Map Global Progress ---
+  if (payload.progress?.match !== undefined) {
+    dictionary.globalMatchNumber = payload.progress.match.toString();
+  }
+
+  // --- Map Current Match (Shared state) ---
+  const currentMatch: Record<string, number> = {};
+  if (payload.progress?.round !== undefined)
+    currentMatch.matchRoundNumber = payload.progress.round;
+  if (payload.playerStats?.health !== undefined)
+    currentMatch.playerHealth = payload.playerStats.health;
+  if (payload.computerStats?.health !== undefined)
+    currentMatch.computerHealth = payload.computerStats.health;
+
+  if (Object.keys(currentMatch).length > 0) {
+    dictionary.currentMatch = JSON.stringify(currentMatch);
+  }
+
+  // --- Map Participant Stats ---
+  const mapParticipant = (
+    prefix: "player" | "computer",
+    stats: Partial<Stats>,
+  ) => {
+    if (stats.wins !== undefined) {
+      dictionary[`${prefix}Score`] = stats.wins.toString();
+    }
+    if (stats.availableTaraMoves !== undefined) {
+      dictionary[`${prefix}TaraCount`] = stats.availableTaraMoves.toString();
+    }
+    if (stats.commonMove) {
+      dictionary[`${prefix}MostCommonMove`] = stats.commonMove;
+      dictionary[`${prefix}MoveCounts`] = JSON.stringify(
+        generateMockMoveCounts(stats.commonMove),
       );
     }
+  };
 
-    if (data.currentMatch) {
-      localStorage.setItem("currentMatch", JSON.stringify(data.currentMatch));
-    }
+  if (payload.playerStats) mapParticipant("player", payload.playerStats);
+  if (payload.computerStats) mapParticipant("computer", payload.computerStats);
 
-    // Set Participant-specific stats based on LocalStorageGameStorage keys
-    if (data.participants) {
-      for (const [participant, stats] of Object.entries(data.participants)) {
-        if (stats.score !== undefined) {
-          localStorage.setItem(`${participant}Score`, stats.score.toString());
-        }
-        if (stats.taraCount !== undefined) {
-          localStorage.setItem(
-            `${participant}TaraCount`,
-            stats.taraCount.toString(),
-          );
-        }
-        if (stats.mostCommonMove) {
-          localStorage.setItem(
-            `${participant}MostCommonMove`,
-            stats.mostCommonMove,
-          );
-        }
-        if (stats.moveCounts) {
-          localStorage.setItem(
-            `${participant}MoveCounts`,
-            JSON.stringify(stats.moveCounts),
-          );
-        }
-      }
-    }
-  }, seedData);
+  return dictionary;
+}
 
-  // 3. Reload the page so the MVC Model constructor picks up the new localStorage values
-  await page.reload();
+/**
+ * Synthesizes the required move counts object to justify the provided "commonMove".
+ */
+function generateMockMoveCounts(commonMove: Move): Record<string, number> {
+  const counts = { rock: 0, paper: 0, scissors: 0 };
+
+  if (commonMove !== Move.TARA) {
+    // Assign an arbitrary high number so the app correctly calculates it as the most common
+    counts[commonMove as keyof typeof counts] = 5;
+  }
+
+  return counts;
 }

--- a/tests/utils/localStorageSeed.ts
+++ b/tests/utils/localStorageSeed.ts
@@ -1,0 +1,77 @@
+import { Page } from "@playwright/test";
+import {
+  Match,
+  MoveCount,
+  Participant,
+  StandardMove,
+} from "../../src/utils/dataObjectUtils";
+
+// 1. Define the optional seeding interfaces
+export interface ParticipantSeed {
+  score?: number;
+  taraCount?: number;
+  mostCommonMove?: StandardMove;
+  moveCounts?: MoveCount;
+}
+
+export interface GameStateSeed {
+  globalMatchNumber?: number;
+  currentMatch?: Match;
+  participants?: Partial<Record<Participant, ParticipantSeed>>;
+}
+
+/**
+ * 2. The utility function to inject state into localStorage.
+ * This runs inside the browser context, so all logic must be self-contained.
+ */
+export async function seedStorage(
+  page: Page,
+  seedData: GameStateSeed,
+): Promise<void> {
+  await page.evaluate((data) => {
+    // Clear existing storage to guarantee a clean slate
+    localStorage.clear();
+
+    // Set Globals
+    if (data.globalMatchNumber !== undefined) {
+      localStorage.setItem(
+        "globalMatchNumber",
+        data.globalMatchNumber.toString(),
+      );
+    }
+
+    if (data.currentMatch) {
+      localStorage.setItem("currentMatch", JSON.stringify(data.currentMatch));
+    }
+
+    // Set Participant-specific stats based on LocalStorageGameStorage keys
+    if (data.participants) {
+      for (const [participant, stats] of Object.entries(data.participants)) {
+        if (stats.score !== undefined) {
+          localStorage.setItem(`${participant}Score`, stats.score.toString());
+        }
+        if (stats.taraCount !== undefined) {
+          localStorage.setItem(
+            `${participant}TaraCount`,
+            stats.taraCount.toString(),
+          );
+        }
+        if (stats.mostCommonMove) {
+          localStorage.setItem(
+            `${participant}MostCommonMove`,
+            stats.mostCommonMove,
+          );
+        }
+        if (stats.moveCounts) {
+          localStorage.setItem(
+            `${participant}MoveCounts`,
+            JSON.stringify(stats.moveCounts),
+          );
+        }
+      }
+    }
+  }, seedData);
+
+  // 3. Reload the page so the MVC Model constructor picks up the new localStorage values
+  await page.reload();
+}


### PR DESCRIPTION
Introduces a state-seeding utility to the Playwright framework, allowing deterministically loading the application into advanced match states without simulating hundreds of manual UI interactions. It also aligns test data structures so the exact same objects can be used symmetrically for both seeding the backend state and validating the frontend UI.

### Key Changes:
- **State Seeding Utility:** Added `tests/utils/localStorageSeed.ts` to cleanly translate our UI-centric test models (`Stats`, `Progress`) into the flat dictionary format required by the application's local storage.
- **Fixture Integration:** Extended `baseTest.ts` with an optional seed fixture, exposing the seeding utility directly to `test` blocks.
- **POM Type Refactoring:** Updated the `GamePage.ts` interfaces to accept pure numbers for wins and strictly excluded `Move.TARA` from the `commonMove` type. The POM now handles translating integers into the UI's zero-padded `string` format.
- **New Test Coverage:** Added the `continueMatch` action to `LandingPage.ts` and created a new test in `landing.spec.ts` that validates the app successfully resumes and renders a complex, mid-game seeded state.