### PR TITLE
[skip deploy] RPST-108: feat(testing): introduce deterministic computer move override and data-driven round E2E tests

### DIFF
--- a/src/utils/computer/AdaptiveComputer.ts
+++ b/src/utils/computer/AdaptiveComputer.ts
@@ -5,12 +5,31 @@ import { getAvailableMoves } from "../gameRules";
 
 export class AdaptiveComputer implements IComputerBrain {
   calculateNextMove(state: GameState): Move {
+    // E2E Test Boundary
+    if (process.env.NODE_ENV !== "production") {
+      const forcedMove = this.checkForTestSetMove();
+      if (forcedMove) return forcedMove;
+    }
+
     const hasTara = state.taras.computer > 0;
     const availableMoves = getAvailableMoves(hasTara);
     const weights = this.getComputerMoveWeights(state, availableMoves);
-    const move = this.chooseWeightedRandomMove(availableMoves, weights);
 
-    return move;
+    return this.chooseWeightedRandomMove(availableMoves, weights);
+  }
+
+  /**
+   * Checks for a forced deterministic move set by an E2E test.
+   * If found, removes it from sessionStorage and returns the move.
+   */
+  private checkForTestSetMove(): Move | null {
+    const key = "__E2E_NEXT_COMPUTER_MOVE__";
+    const e2eForcedMove = sessionStorage.getItem(key);
+    if (e2eForcedMove) {
+      sessionStorage.removeItem(key);
+      return e2eForcedMove as Move;
+    }
+    return null;
   }
 
   private getBaseWeights(): Record<Move, number> {

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -1,17 +1,131 @@
 import { test } from "../baseTest";
-import { Move } from "../models/GamePage";
+import { Move, Participant, Progress, Stats } from "../models/GamePage";
 
-test.describe("Core Gameplay", () => {
+type StandardMove = NonNullable<Stats["commonMove"]>;
+
+interface RoundTestCase {
+  description: string;
+  movePlayer: StandardMove;
+  moveComputer: StandardMove;
+  expectedWinner: Participant;
+}
+
+const defaultStats: Stats = {
+  availableTaraMoves: 0,
+  commonMove: null,
+  health: 100,
+  wins: 0,
+};
+
+const defaultProgress: Progress = {
+  match: 1,
+  round: 1,
+};
+
+const roundTestCases: RoundTestCase[] = [
+  {
+    description: "Player PAPER engulfs Computer ROCK",
+    movePlayer: Move.PAPER,
+    moveComputer: Move.ROCK,
+    expectedWinner: Participant.PLAYER,
+  },
+  {
+    description: "Player ROCK crushes Computer SCISSORS",
+    movePlayer: Move.ROCK,
+    moveComputer: Move.SCISSORS,
+    expectedWinner: Participant.PLAYER,
+  },
+  {
+    description: "Player SCISSORS cuts Computer PAPER",
+    movePlayer: Move.SCISSORS,
+    moveComputer: Move.PAPER,
+    expectedWinner: Participant.PLAYER,
+  },
+  {
+    description: "Computer ROCK crushes Player SCISSORS",
+    movePlayer: Move.SCISSORS,
+    moveComputer: Move.ROCK,
+    expectedWinner: Participant.COMPUTER,
+  },
+];
+
+test.describe("Round 1", () => {
   test.beforeEach(async ({ landingPage }) => {
     await landingPage.startMatch();
   });
 
-  for (const playerMove of [Move.ROCK, Move.PAPER, Move.SCISSORS]) {
-    test(`should annnounce when the player selects ${playerMove}`, async ({
-      gamePage,
-    }) => {
-      await gamePage.choosePlayerAction(playerMove);
-      await gamePage.verifyPlayerActionAnnouncement(playerMove);
+  for (const {
+    description,
+    movePlayer,
+    moveComputer,
+    expectedWinner,
+  } of roundTestCases) {
+    test(description, async ({ gamePage }) => {
+      // 1. Dynamic State Derivation
+      // Calculates the symmetrical outcomes based purely on who won.
+      const isPlayerWinner = expectedWinner === Participant.PLAYER;
+
+      const expectedPlayerStats: Stats = {
+        availableTaraMoves: isPlayerWinner ? 1 : 0,
+        commonMove: movePlayer,
+        health: isPlayerWinner ? 100 : 50,
+        wins: 0,
+      };
+
+      const expectedComputerStats: Stats = {
+        availableTaraMoves: !isPlayerWinner ? 1 : 0,
+        commonMove: moveComputer,
+        health: !isPlayerWinner ? 100 : 50,
+        wins: 0,
+      };
+
+      const expectedProgress: Progress = {
+        match: 1,
+        round: 2,
+      };
+
+      // Status text expectations
+      const expectedAnnouncement = new RegExp(
+        `${expectedWinner} lands a blow`,
+        "i",
+      );
+      const expectedStatus1 = "Choose your attack!";
+      const expectedStatus2 = new RegExp(
+        `you played ${movePlayer}. computer played ${moveComputer}.`,
+        "i",
+      );
+      const expectedStatus3 = "Prepare your next move...";
+
+      // 2. Execution & Symmetrical Verification
+      await test.step("Verify default initial game state", async () => {
+        await Promise.all([
+          gamePage.verifyStats(Participant.PLAYER, defaultStats),
+          gamePage.verifyProgress(defaultProgress),
+          gamePage.verifyStats(Participant.COMPUTER, defaultStats),
+          gamePage.verifyStatus(expectedStatus1),
+        ]);
+      });
+
+      await test.step(`Participant moves: Player (${movePlayer}) vs Computer (${moveComputer})`, async () => {
+        await gamePage.setComputerMove(moveComputer);
+        await gamePage.choosePlayerAction(movePlayer);
+        await gamePage.verifyStatus(expectedStatus2);
+      });
+
+      await test.step("Verify updated game state", async () => {
+        // Sequential checks for transient UI states
+        await gamePage.verifyAnnouncement(expectedAnnouncement);
+        await gamePage.verifyStatus(expectedStatus3);
+        await gamePage.verifyStatus(expectedStatus1);
+        if (isPlayerWinner) await gamePage.verifyTaraEnabled();
+
+        // Concurrent symmetrical checks for structural state
+        await Promise.all([
+          gamePage.verifyStats(Participant.PLAYER, expectedPlayerStats),
+          gamePage.verifyProgress(expectedProgress),
+          gamePage.verifyStats(Participant.COMPUTER, expectedComputerStats),
+        ]);
+      });
     });
   }
 });

--- a/tests/models/GamePage.ts
+++ b/tests/models/GamePage.ts
@@ -29,6 +29,7 @@ export interface Stats {
 export class GamePage {
   readonly page: Page;
 
+  readonly announcementContainer: Locator;
   readonly progressContainer: Locator;
   readonly progressMatchHeading: Locator;
   readonly progressRoundHeading: Locator;
@@ -37,6 +38,7 @@ export class GamePage {
   constructor(page: Page) {
     this.page = page;
 
+    this.announcementContainer = page.locator("#announcement-container");
     this.progressContainer = page.locator("#game-progress-container");
     this.progressMatchHeading = this.progressContainer.locator("h2");
     this.progressRoundHeading = this.progressContainer.locator("h3");
@@ -104,9 +106,12 @@ export class GamePage {
   // VERIFICATION MISCELLANEOUS
   // ====================================================
 
-  async verifyPlayerActionAnnouncement(playerAction: Move): Promise<void> {
-    const regex = new RegExp(`you played ${playerAction}`, "i");
-    await expect(this.statusContainer).toContainText(regex);
+  async verifyAnnouncement(
+    expectedAnnouncement: RegExp | string,
+  ): Promise<void> {
+    await expect(this.announcementContainer).toContainText(
+      expectedAnnouncement,
+    );
   }
 
   async verifyPlayerButtonsVisible(isVisible = true): Promise<void> {
@@ -126,6 +131,10 @@ export class GamePage {
         new RegExp(`round ${progress.round}`, "i"),
       ),
     ]);
+  }
+
+  async verifyStatus(expectedStatus: RegExp | string): Promise<void> {
+    await expect(this.statusContainer).toContainText(expectedStatus);
   }
 
   async verifyStatusVisible(isVisible = true): Promise<void> {

--- a/tests/models/GamePage.ts
+++ b/tests/models/GamePage.ts
@@ -94,6 +94,12 @@ export class GamePage {
     await this.playerAction(action).click();
   }
 
+  async setComputerMove(move: Move): Promise<void> {
+    await this.page.evaluate((m) => {
+      sessionStorage.setItem("__E2E_NEXT_COMPUTER_MOVE__", m);
+    }, move);
+  }
+
   // ====================================================
   // VERIFICATION MISCELLANEOUS
   // ====================================================


### PR DESCRIPTION
Establishes complete determinism over the core gameplay loop within our Playwright E2E automation suite. By establishing a safe test backdoor to override the computer's RNG, we can now evaluate strict state-assertion symmetry (health drops, progress updates, and layout hydration) across varying round outcomes.

Key Changes
- **Application Layer (`AdaptiveComputer.ts`):** Added a `process.env.NODE_ENV !== "production"` boundary check. When running tests, the engine checks for an `__E2E_NEXT_COMPUTER_MOVE__` key in `sessionStorage`, consuming it instantly to enforce a deterministic match flow.
- **Page Object Model (`GamePage.ts`):** Exposed `setComputerMove()` to inject the desired computer behavior directly into the browser context mid-test. Added robust locators and wrappers for transient UI messaging elements (`#announcement-container`).
- **Test Suite (`game.spec.ts`):** Re-architected core gameplay specifications into an typed, data-driven array (`RoundTestCase[]`). The loop handles complete dynamic state derivation—calculating expected player vs. computer health, wins, and messaging layouts strictly based on the defined round winner.