### PR TITLE
RPST-109: fix: copy default move counts to prevent reference sharing between participants

### DIFF
--- a/src/model/model.test.ts
+++ b/src/model/model.test.ts
@@ -112,6 +112,20 @@ describe("Model", () => {
     model = new Model(mockGameStorage);
   });
 
+  test("uses independent default move counts for each participant after a fresh load", () => {
+    localStorage.clear();
+
+    const freshModel = new Model();
+
+    freshModel.registerPlayerMove(MOVES.ROCK);
+
+    expect(freshModel["state"].moveCounts.player.rock).toBe(1);
+    expect(freshModel["state"].moveCounts.computer.rock).toBe(0);
+    expect(freshModel["state"].moveCounts.player).not.toBe(
+      freshModel["state"].moveCounts.computer,
+    );
+  });
+
   describe("Scores", () => {
     test("getScore returns 0 when no score is set", () => {
       expect(model.getPlayerScore()).toBe(0);

--- a/src/storage/localStorageGameStorage.ts
+++ b/src/storage/localStorageGameStorage.ts
@@ -69,10 +69,19 @@ export class LocalStorageGameStorage implements IGameStorage {
     const key = this.formatKey(participant, KEY_SUFFIX_MOVE_COUNTS);
     try {
       const raw = localStorage.getItem(key);
-      return raw ? JSON.parse(raw) : DEFAULT_MOVE_COUNTS;
+      if (!raw) {
+        return { ...DEFAULT_MOVE_COUNTS };
+      }
+
+      const parsed = JSON.parse(raw) as MoveCount;
+      return {
+        rock: parsed.rock ?? 0,
+        paper: parsed.paper ?? 0,
+        scissors: parsed.scissors ?? 0,
+      };
     } catch (e) {
       console.warn(`LocalStorage Error: Failed to parse "${key}".`, e);
-      return DEFAULT_MOVE_COUNTS;
+      return { ...DEFAULT_MOVE_COUNTS };
     }
   }
 


### PR DESCRIPTION
`localStorageGameStorage.ts` was returning the literal `DEFAULT_MOVE_COUNTS` reference when local storage was empty or threw an error. Because this reference was shared, updates to the player's move counts accidentally mutated the computer's counts as well.

## Solution:
- Updated l`ocalStorageGameStorage.ts` to return a new object literal (`{ ...DEFAULT_MOVE_COUNTS }`) during fallback scenarios.
- Sanitized the parsed storage object to guarantee a fresh structure.
- Added a regression test in `model.test.ts` to verify that player and computer move counts remain completely decoupled after a fresh load.

### Changes:
- `src/storage/localStorageGameStorage.ts`: Decoupled fallback references and explicit parsing assignment.
- `src/model/model.test.ts`: Added isolation regression test.