### PR TITLE
[skip deploy] RPST-101: refactor(test): centralize game data models and default state

### DIFF
--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -1,5 +1,12 @@
 import { test } from "../baseTest";
-import { Move, Participant, Progress, Stats } from "../models/GamePage";
+import {
+  defaultProgress,
+  defaultStats,
+  Move,
+  Participant,
+  Progress,
+  Stats,
+} from "../utils/data";
 
 type StandardMove = NonNullable<Stats["commonMove"]>;
 
@@ -9,18 +16,6 @@ interface RoundTestCase {
   moveComputer: StandardMove;
   expectedWinner: Participant;
 }
-
-const defaultStats: Stats = {
-  availableTaraMoves: 0,
-  commonMove: null,
-  health: 100,
-  wins: 0,
-};
-
-const defaultProgress: Progress = {
-  match: 1,
-  round: 1,
-};
 
 const roundTestCases: RoundTestCase[] = [
   {

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,22 +1,17 @@
 import { test } from "../baseTest";
-import { Move, Participant, Progress, Stats } from "../models/GamePage";
+import {
+  defaultProgress,
+  defaultStats,
+  Move,
+  Participant,
+  Progress,
+  Stats,
+} from "../utils/data";
 
 test("loads default match UI with no saved game state", async ({
   gamePage,
   landingPage,
 }) => {
-  const defaultStats: Stats = {
-    availableTaraMoves: 0,
-    commonMove: null,
-    health: 100,
-    wins: 0,
-  };
-
-  const defaultProgress: Progress = {
-    match: 1,
-    round: 1,
-  };
-
   await test.step("Start match from landing page", async () => {
     await landingPage.verifyHeadingVisible();
     await landingPage.startMatch();

--- a/tests/models/GamePage.ts
+++ b/tests/models/GamePage.ts
@@ -1,30 +1,11 @@
 import { expect, Locator, Page } from "@playwright/test";
-
-const MAX_TARA_MOVES = 3;
-
-export enum Move {
-  PAPER = "paper",
-  ROCK = "rock",
-  SCISSORS = "scissors",
-  TARA = "tara",
-}
-
-export enum Participant {
-  COMPUTER = "computer",
-  PLAYER = "player",
-}
-
-export interface Progress {
-  match: number;
-  round: number;
-}
-
-export interface Stats {
-  availableTaraMoves: number;
-  commonMove: Exclude<Move, Move.TARA> | null;
-  health: number;
-  wins: number;
-}
+import {
+  MAX_TARA_MOVES,
+  Move,
+  Participant,
+  Progress,
+  Stats,
+} from "../utils/data";
 
 export class GamePage {
   readonly page: Page;

--- a/tests/utils/data.ts
+++ b/tests/utils/data.ts
@@ -1,0 +1,37 @@
+export const defaultStats: Stats = {
+  availableTaraMoves: 0,
+  commonMove: null,
+  health: 100,
+  wins: 0,
+};
+
+export const defaultProgress: Progress = {
+  match: 1,
+  round: 1,
+};
+
+export const MAX_TARA_MOVES = 3;
+
+export enum Move {
+  PAPER = "paper",
+  ROCK = "rock",
+  SCISSORS = "scissors",
+  TARA = "tara",
+}
+
+export enum Participant {
+  COMPUTER = "computer",
+  PLAYER = "player",
+}
+
+export interface Progress {
+  match: number;
+  round: number;
+}
+
+export interface Stats {
+  availableTaraMoves: number;
+  commonMove: Exclude<Move, Move.TARA> | null;
+  health: number;
+  wins: number;
+}

--- a/tests/utils/localStorageSeed.ts
+++ b/tests/utils/localStorageSeed.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { Move, Progress, Stats } from "../models/GamePage";
+import { Move, Progress, Stats } from "../utils/data";
 
 export interface SeedPayload {
   progress?: Partial<Progress>;


### PR DESCRIPTION
Extracts shared TypeScript interfaces, enums, and default state objects out of individual spec files and Page Object Models to establish a centralized source of truth for test data.

## Changes Included 
- Created `tests/utils/data.ts` to house common data structures.
- Relocated `Move` and `Participant` `enums`, `Progress` and `Stats` `interfaces`, and `MAX_TARA_MOVES` from `GamePage.ts`.
- Removed localized, duplicated instantiations of `defaultStats` and `defaultProgress` from `game.spec.ts` and `landing.spec.ts`.
- Updated import paths across the e2e suite to utilize the new data utility.

### Impact
Decouples data models from the UI layer (POMs) and reduces boilerplate in spec files, significantly improving codebase maintainability and consistency.